### PR TITLE
add in freeCompilerArgs to get rid of build warning

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -45,6 +45,7 @@ kotlin {
         iosTarget.binaries.framework {
             baseName = "ComposeApp"
             isStatic = true
+            freeCompilerArgs += listOf("-Xbinary=bundleId=com.overdrive.cruiser")
         }
     }
     


### PR DESCRIPTION
Prevents this warning when building: "w: Cannot infer a bundle ID from packages of source files and exported dependencies, use the bundle name instead: ComposeApp. Please specify the bundle ID explicitly using the -Xbinary=bundleId=<id> compiler flag.</id>"