### PR TITLE
Get spots from parkade, display them

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.skie)
+    alias(libs.plugins.serialization)
 }
 
 kotlin {
@@ -55,6 +56,8 @@ kotlin {
             implementation(libs.androidx.activity.compose)
             implementation(libs.mapbox.maps.android)
             implementation(libs.mapbox.maps.compose)
+            implementation(libs.ktor.client.okhttp)
+            implementation(libs.kotlinx.coroutines.android)
         }
         commonMain.dependencies {
             implementation(compose.runtime)
@@ -65,6 +68,11 @@ kotlin {
             implementation(compose.components.uiToolingPreview)
             implementation(libs.androidx.lifecycle.viewmodel)
             implementation(libs.androidx.lifecycle.runtime.compose)
+            implementation(libs.bundles.ktor.common)
+            implementation(libs.kotlinx.coroutines.core)
+        }
+        iosMain.dependencies {
+            implementation(libs.ktor.client.darwin)
         }
     }
 }

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@android:style/Theme.Material.Light.NoActionBar">
+        android:theme="@android:style/Theme.Material.Light.NoActionBar"
+        android:usesCleartextTraffic="true">
         <activity
             android:exported="true"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"

--- a/composeApp/src/androidMain/kotlin/com/overdrive/cruiser/MapView.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/overdrive/cruiser/MapView.android.kt
@@ -3,10 +3,12 @@ package com.overdrive.cruiser
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import com.mapbox.geojson.Point
 import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.compose.DefaultSettingsProvider.defaultAttributionSettings
 import com.mapbox.maps.extension.compose.DefaultSettingsProvider.defaultCompassSettings
@@ -14,12 +16,16 @@ import com.mapbox.maps.extension.compose.DefaultSettingsProvider.defaultLogoSett
 import com.mapbox.maps.extension.compose.DefaultSettingsProvider.defaultScaleBarSettings
 import com.mapbox.maps.extension.compose.MapboxMap
 import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
+import com.mapbox.maps.extension.compose.annotation.generated.CircleAnnotationGroup
+import com.mapbox.maps.plugin.annotation.generated.CircleAnnotationOptions
+import com.overdrive.cruiser.models.Spot
 
 @OptIn(MapboxExperimental::class)
 @Composable
-actual fun MapView(
+actual fun SpotMapView(
     modifier: Modifier,
     contentPadding: PaddingValues,
+    spots: List<Spot>
 )  = with(LocalDensity.current) {
     val context = LocalContext.current
 
@@ -59,16 +65,29 @@ actual fun MapView(
 
     MapboxMap(
         modifier = modifier.fillMaxSize(),
-        mapViewportState = MapViewportState().apply{
-            setCameraOptions(
-                com.mapbox.maps.CameraOptions.Builder().center(
-                    com.mapbox.geojson.Point.fromLngLat(16.3719, 48.2082)
-                ).zoom(10.0).build()
-            )
+        mapViewportState = remember { MapViewportState() }.apply {
+            LaunchedEffect(spots) {
+                if (spots.isNotEmpty()) {
+                    setCameraOptions(
+                        com.mapbox.maps.CameraOptions.Builder().center(
+                            Point.fromLngLat(spots[0].longitude, spots[0].latitude)
+                        ).zoom(10.0).build()
+                    )
+                }
+            }
         },
         logoSettings = logoSettings,
         scaleBarSettings = scaleBarSettings,
         attributionSettings = attributionSettings,
         compassSettings = compassSettings,
-    )
+    ) {
+        CircleAnnotationGroup(
+            annotations = spots.map { spot ->
+               CircleAnnotationOptions()
+                   .withPoint(Point.fromLngLat(spot.longitude, spot.latitude))
+                   .withCircleColor("#FF0000")
+                   .withCircleRadius(10.0)
+            }
+        )
+    }
 }

--- a/composeApp/src/androidMain/kotlin/com/overdrive/cruiser/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/overdrive/cruiser/Platform.android.kt
@@ -7,3 +7,5 @@ class AndroidPlatform : Platform {
 }
 
 actual fun getPlatform(): Platform = AndroidPlatform()
+
+actual fun getPlatformBasicName(): String = "Android"

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/App.kt
@@ -11,15 +11,20 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.overdrive.cruiser.models.Spot
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 import cruiser.composeapp.generated.resources.Res
 import cruiser.composeapp.generated.resources.compose_multiplatform
+import kotlinx.coroutines.launch
 
 @Composable
 @Preview
 fun App() {
+    val scope = rememberCoroutineScope()
+    var spots by remember { mutableStateOf(emptyList<Spot>()) }
+
     MaterialTheme {
         var showContent by remember { mutableStateOf(false) }
         Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
@@ -27,13 +32,26 @@ fun App() {
                 Text("Click me!")
             }
             AnimatedVisibility(showContent) {
-                val greeting = remember { Greeting().greet() }
+                val greeting = remember { "hello" }
                 Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
                     Image(painterResource(Res.drawable.compose_multiplatform), null)
                     Text("Compose: $greeting")
                 }
             }
-            MapView(modifier = Modifier.fillMaxSize())
+            LaunchedEffect(true){
+                scope.launch {
+                    spots = try {
+                        SpotFetcher().fetch()
+                    } catch (e: Exception) {
+                        println(e.message ?: "Error")
+                        emptyList()
+                    }
+                }
+            }
+            SpotMapView(
+                modifier = Modifier.fillMaxSize(),
+                spots = spots,
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/Greeting.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/Greeting.kt
@@ -1,9 +1,0 @@
-package com.overdrive.cruiser
-
-class Greeting {
-    private val platform = getPlatform()
-
-    fun greet(): String {
-        return "Hello, ${platform.name}!"
-    }
-}

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/Platform.kt
@@ -5,3 +5,5 @@ interface Platform {
 }
 
 expect fun getPlatform(): Platform
+
+expect fun getPlatformBasicName(): String

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/SpotFetcher.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/SpotFetcher.kt
@@ -1,0 +1,16 @@
+package com.overdrive.cruiser
+
+import com.overdrive.cruiser.models.Spot
+import com.overdrive.cruiser.utils.requestGet
+
+class SpotFetcher {
+    suspend fun fetch(): List<Spot> {
+        val spots: List<Spot> = fetchSpots()
+        return spots
+    }
+
+    private suspend fun fetchSpots(): List<Spot> {
+        val endpoint = "/spots"
+        return requestGet(endpoint)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/SpotMapView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/SpotMapView.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.overdrive.cruiser.models.Spot
 
 @Composable
-expect fun MapView(
+expect fun SpotMapView(
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(all = 0.dp),
+    spots: List<Spot> = emptyList(),
 )

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/models/Spot.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/models/Spot.kt
@@ -1,0 +1,13 @@
+package com.overdrive.cruiser.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Spot(
+    @SerialName("id") val id: String,
+    @SerialName("ownerId") val ownerId: String,
+    @SerialName("address") val address: String,
+    @SerialName("latitude") val latitude: Double,
+    @SerialName("longitude") val longitude: Double,
+)

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/utils/Request.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/utils/Request.kt
@@ -1,0 +1,33 @@
+package com.overdrive.cruiser.utils
+
+import com.overdrive.cruiser.getPlatformBasicName
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.serialization.json.Json
+
+// Temporary logic while working with localhost api
+val BASE_URL: String =
+    when (getPlatformBasicName()) {
+        "iOS" -> "http://localhost:8080"
+        "Android" -> "http://10.0.2.2:8080"
+        else -> throw Error("INVALID PLATFORM: unable to determine API base")
+    }
+
+val httpClient = HttpClient {
+    install(io.ktor.client.plugins.contentnegotiation.ContentNegotiation) {
+        json(
+            Json {
+                prettyPrint = true
+                isLenient = true
+                ignoreUnknownKeys = true
+            })
+    }
+}
+
+suspend inline fun <reified T> requestGet(endpoint: String): T {
+    val response: HttpResponse = httpClient.get(BASE_URL + endpoint)
+    return response.body()
+}

--- a/composeApp/src/iosMain/kotlin/com/overdrive/cruiser/MapView.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/overdrive/cruiser/MapView.ios.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.interop.UIKitViewController
+import com.overdrive.cruiser.models.Spot
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -12,17 +13,20 @@ import platform.UIKit.UIViewController
 
 @OptIn(ExperimentalForeignApi::class)
 @Composable
-actual fun MapView(
+actual fun SpotMapView(
     modifier: Modifier,
     contentPadding: PaddingValues,
+    spots: List<Spot>,
 ) {
     val contentPaddingState = remember { MutableStateFlow(contentPadding) }
-    val factory = remember { mapWithSwiftViewFactory(contentPaddingState) }
+    val contentSpotsState = remember { MutableStateFlow(spots) }
+    val factory = remember { mapWithSwiftViewFactory(contentPaddingState, contentSpotsState) }
 
     UIKitViewController(
         factory = { factory.viewController },
         update = {
             contentPaddingState.value = contentPadding
+            contentSpotsState.value = spots
         },
         modifier = modifier,
     )
@@ -30,6 +34,7 @@ actual fun MapView(
 
 internal lateinit var mapWithSwiftViewFactory: (
     contentPaddingState: StateFlow<PaddingValues>,
+    contentSpotsState: StateFlow<List<Spot>>,
 ) -> MapWithSwiftViewFactory
 
 interface MapWithSwiftViewFactory {

--- a/composeApp/src/iosMain/kotlin/com/overdrive/cruiser/Platform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/overdrive/cruiser/Platform.ios.kt
@@ -7,3 +7,5 @@ class IOSPlatform: Platform {
 }
 
 actual fun getPlatform(): Platform = IOSPlatform()
+
+actual fun getPlatformBasicName(): String = "iOS"

--- a/composeApp/src/iosMain/kotlin/com/overdrive/cruiser/ViewFactory.kt
+++ b/composeApp/src/iosMain/kotlin/com/overdrive/cruiser/ViewFactory.kt
@@ -1,12 +1,14 @@
 package com.overdrive.cruiser
 
 import androidx.compose.foundation.layout.PaddingValues
+import com.overdrive.cruiser.models.Spot
 import kotlinx.coroutines.flow.StateFlow
 
 // Called from Swift - initializes the MapView
 fun setViewFactories(
     mapWithSwiftViewFactory: (
         contentPaddingState: StateFlow<PaddingValues>,
+        contentSpotsState: StateFlow<List<Spot>>,
     ) -> MapWithSwiftViewFactory,
 ) {
     com.overdrive.cruiser.mapWithSwiftViewFactory = mapWithSwiftViewFactory

--- a/composeApp/src/wasmJsMain/kotlin/com/overdrive/cruiser/MapView.wasm.kt
+++ b/composeApp/src/wasmJsMain/kotlin/com/overdrive/cruiser/MapView.wasm.kt
@@ -3,11 +3,13 @@ package com.overdrive.cruiser
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.overdrive.cruiser.models.Spot
 
 @Composable
-actual fun MapView(
+actual fun SpotMapView(
     modifier: Modifier,
     contentPadding: PaddingValues,
+    spots: List<Spot>
 ) {
     // TODO: Implement
 }

--- a/composeApp/src/wasmJsMain/kotlin/com/overdrive/cruiser/Platform.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/com/overdrive/cruiser/Platform.wasmJs.kt
@@ -5,3 +5,5 @@ class WasmPlatform: Platform {
 }
 
 actual fun getPlatform(): Platform = WasmPlatform()
+
+actual fun getPlatformBasicName(): String = "Web"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ agp = "8.2.2"
 android-compileSdk = "34"
 android-minSdk = "24"
 android-targetSdk = "34"
-androidx-activityCompose = "1.9.1"
+androidx-activityCompose = "1.9.2"
 androidx-appcompat = "1.7.0"
 androidx-constraintlayout = "2.1.4"
 androidx-core-ktx = "1.13.1"
@@ -16,6 +16,8 @@ junit = "4.13.2"
 kotlin = "2.0.20"
 mapbox = "11.2.0"
 touchlab-skie = "0.9.0-RC.5"
+coroutines = "1.9.0"
+ktor = "3.0.0-rc-1"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -32,6 +34,20 @@ androidx-lifecycle-viewmodel = { group = "org.jetbrains.androidx.lifecycle", nam
 androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 mapbox-maps-android = { module = "com.mapbox.maps:android", version.ref = "mapbox" }
 mapbox-maps-compose = { module = "com.mapbox.extension:maps-compose", version.ref = "mapbox" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
+ktor = { group = "io.ktor", name = "ktor", version.ref = "ktor" }
+ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
+ktor-client-json = { group = "io.ktor", name = "ktor-client-json", version.ref = "ktor" }
+ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
+ktor-client-serialization = { group = "io.ktor", name = "ktor-client-serialization", version.ref = "ktor" }
+ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
+
+[bundles]
+ktor-common = ["ktor-client-core", "ktor-client-json", "ktor-client-logging", "ktor-client-serialization", "ktor-client-content-negotiation", "ktor-serialization-kotlinx-json"]
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
@@ -40,3 +56,4 @@ jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "compose-plugin
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 skie = { id = "co.touchlab.skie", version.ref = "touchlab-skie" }
+serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,6 +34,8 @@ dependencyResolutionManagement {
             credentials.password = providers.gradleProperty("MAPBOX_DOWNLOADS_TOKEN").get()
             authentication.create<BasicAuthentication>("basic")
         }
+        // To support WASM
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/wasm/experimental")
     }
 }
 


### PR DESCRIPTION
As title suggests this PR makes cruiser reach out to parkade for "spots", and displays them on the map.

We will be using `ktor-client` for HTTP requests, and by using the packages in this PR there is minimal unpacking to be done.

I renamed `MapView` to `SpotMapView` to avoid a collision with mapbox libraries.

I've used `LaunchedEffect` and similar methods to handle the case of a failed request (live updates).

NOTE: You will need to run the backend in order for the map to fill with spots.


Proof of compile:

![Screenshot 2024-09-24 at 6 45 09 PM](https://github.com/user-attachments/assets/2824a9c0-623a-4e7d-a0b5-a1c33756e933)