### PR TITLE
create basic navigation bar

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/App.kt
@@ -3,11 +3,8 @@ package com.overdrive.cruiser
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.Button
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -48,10 +45,7 @@ fun App() {
                     }
                 }
             }
-            SpotMapView(
-                modifier = Modifier.fillMaxSize(),
-                spots = spots,
-            )
+            Navigation(spots)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/Navigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/Navigation.kt
@@ -1,0 +1,52 @@
+package com.overdrive.cruiser
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import com.overdrive.cruiser.models.Spot
+
+
+@Composable
+fun Navigation(spots: List<Spot>) {
+    var selectedScreen by remember { mutableStateOf("Map") }
+
+    Scaffold(
+        bottomBar = {
+            BottomNavigation {
+                BottomNavigationItem(
+                    icon = { Icon(Icons.Filled.LocationOn, contentDescription = null) },
+                    label = { Text("Map") },
+                    selected = selectedScreen == "Map",
+                    onClick = { selectedScreen = "Map" }
+                )
+                BottomNavigationItem(
+                    icon = { Icon(Icons.Filled.Person, contentDescription = null) },
+                    label = { Text("User") },
+                    selected = selectedScreen == "User",
+                    onClick = { selectedScreen = "User" }
+                )
+                BottomNavigationItem(
+                    icon = { Icon(Icons.Filled.Settings, contentDescription = null) },
+                    label = { Text("Settings") },
+                    selected = selectedScreen == "Settings",
+                    onClick = { selectedScreen = "Settings" }
+                )
+            }
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier.padding(innerPadding)
+        ) {
+            when (selectedScreen) {
+                "Map" -> MapView(spots)
+                "User" -> UserView()
+                "Settings" -> SettingsView()
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/Views.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/Views.kt
@@ -1,0 +1,26 @@
+package com.overdrive.cruiser
+
+import androidx.compose.runtime.Composable
+import androidx.compose.material.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.fillMaxSize
+import com.overdrive.cruiser.models.Spot
+
+
+@Composable
+fun UserView() {
+    Text("User Screen")
+}
+
+@Composable
+fun SettingsView() {
+    Text("Settings Screen")
+}
+
+@Composable
+fun MapView(spots: List<Spot>) {
+    SpotMapView(
+        modifier = Modifier.fillMaxSize(),
+        spots = spots,
+    )
+}


### PR DESCRIPTION
Creates a basic navigation bar with a view for map, user profile, and settings. Didn't add any formatting for the time being. When the app is launched, it should default to the map view. Shouldn't require any special build instructions.

<img width="328" alt="image" src="https://github.com/user-attachments/assets/847ff61e-7de4-4a80-9051-bbbc1a57d085">
<img width="309" alt="image" src="https://github.com/user-attachments/assets/24a13f93-1939-4100-bfc7-7393662e2bbe">
<img width="306" alt="image" src="https://github.com/user-attachments/assets/44098117-c85f-4f64-b9ba-40d30dfd2cbd">
