### PR TITLE
Add GoogleSignIn support on Android/iOS

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
     alias(libs.plugins.jetbrainsCompose) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
+    alias(libs.plugins.kotlinCocoapods) apply false
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 
 plugins {
@@ -10,9 +11,30 @@ plugins {
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.skie)
     alias(libs.plugins.serialization)
+    alias(libs.plugins.kotlinCocoapods)
 }
 
 kotlin {
+    cocoapods {
+        version = "1.0"
+        summary = "Shared code of this project"
+        homepage = "Link to a Kotlin/Native module homepage"
+        ios.deploymentTarget = "15.3"
+        name = "Shared"
+
+        framework {
+            baseName = "Shared"
+            isStatic = false
+        }
+
+        pod("GoogleSignIn") {
+            version = "8.0.0"
+        }
+
+        xcodeConfigurationToNativeBuildType["CUSTOM_DEBUG"] = NativeBuildType.DEBUG
+        xcodeConfigurationToNativeBuildType["CUSTOM_RELEASE"] = NativeBuildType.RELEASE
+    }
+
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         moduleName = "composeApp"
@@ -58,6 +80,10 @@ kotlin {
             implementation(libs.mapbox.maps.compose)
             implementation(libs.ktor.client.okhttp)
             implementation(libs.kotlinx.coroutines.android)
+            implementation(libs.androidx.credentials)
+            implementation(libs.androidx.credentials.play.services.auth)
+            implementation(libs.google.id)
+            implementation(libs.koin.android)
         }
         commonMain.dependencies {
             implementation(compose.runtime)
@@ -70,6 +96,9 @@ kotlin {
             implementation(libs.androidx.lifecycle.runtime.compose)
             implementation(libs.bundles.ktor.common)
             implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.koin.compose)
+            implementation(libs.koin.compose.viewmodel)
+            implementation(libs.koin.compose.viewmodel.navigation)
         }
         iosMain.dependencies {
             implementation(libs.ktor.client.darwin)

--- a/composeApp/src/androidMain/kotlin/com/overdrive/cruiser/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/overdrive/cruiser/MainActivity.kt
@@ -5,10 +5,18 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import com.overdrive.cruiser.utils.appModule
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.context.startKoin
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        startKoin{
+            androidContext(this@MainActivity)
+            modules(appModule)
+        }
 
         setContent {
             App()

--- a/composeApp/src/androidMain/kotlin/com/overdrive/cruiser/auth/GoogleAuthProvider.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/overdrive/cruiser/auth/GoogleAuthProvider.android.kt
@@ -1,0 +1,25 @@
+package com.overdrive.cruiser.auth
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.credentials.ClearCredentialStateRequest
+import androidx.credentials.CredentialManager
+
+internal class GoogleAuthProviderImpl(
+    private val credentials: GoogleAuthCredentials,
+    private val credentialManager: CredentialManager,
+): GoogleAuthProvider {
+    @Composable
+    override fun getUiProvider(): GoogleAuthUiProvider {
+        val activityContext = LocalContext.current
+        return GoogleAuthUiProviderImpl(
+            activityContext = activityContext,
+            credentialManager = credentialManager,
+            credentials = credentials
+        )
+    }
+
+    override suspend fun signOut() {
+        credentialManager.clearCredentialState(ClearCredentialStateRequest())
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/overdrive/cruiser/auth/GoogleAuthUiProvider.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/overdrive/cruiser/auth/GoogleAuthUiProvider.android.kt
@@ -1,0 +1,66 @@
+package com.overdrive.cruiser.auth
+
+import android.content.Context
+import androidx.credentials.Credential
+import androidx.credentials.CredentialManager
+import androidx.credentials.CustomCredential
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.exceptions.GetCredentialException
+import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
+
+internal class GoogleAuthUiProviderImpl(
+    private val activityContext: Context,
+    private val credentialManager: CredentialManager,
+    private val credentials: GoogleAuthCredentials,
+): GoogleAuthUiProvider {
+    override suspend fun signIn(): GoogleUser? {
+        return try {
+            val credential = credentialManager.getCredential(
+                context = activityContext,
+                request = getCredentialRequest()
+            ).credential
+            getGoogleUserFromCredential(credential)
+        } catch (e: GetCredentialException) {
+            println("GoogleAuthUiProvider error: ${e.message}")
+            null
+        } catch (e: NullPointerException) {
+            null
+        }
+    }
+
+    private fun getGoogleUserFromCredential(credential: Credential): GoogleUser? {
+        return when {
+            credential is CustomCredential && credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL -> {
+                try {
+                    val googleIdTokenCredential =
+                        GoogleIdTokenCredential.createFrom(credential.data)
+                    GoogleUser(
+                        idToken = googleIdTokenCredential.idToken,
+                        displayName = googleIdTokenCredential.displayName ?: "",
+                        profilePicUrl = googleIdTokenCredential.profilePictureUri?.toString()
+                    )
+                } catch (e: GoogleIdTokenParsingException) {
+                    println("GoogleAuthUiProvider Received an invalid google id token response: ${e.message}")
+                    null
+                }
+            }
+            else -> null
+        }
+    }
+
+    private fun getCredentialRequest(): GetCredentialRequest {
+        return GetCredentialRequest.Builder()
+            .addCredentialOption(getGoogleIdOption(serverClientId = credentials.serverId))
+            .build()
+    }
+
+    private fun getGoogleIdOption(serverClientId: String): GetGoogleIdOption {
+        return GetGoogleIdOption.Builder()
+            .setFilterByAuthorizedAccounts(false)
+            .setAutoSelectEnabled(true)
+            .setServerClientId(serverClientId)
+            .build()
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/overdrive/cruiser/utils/KoinInit.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/overdrive/cruiser/utils/KoinInit.android.kt
@@ -1,0 +1,17 @@
+package com.overdrive.cruiser.utils
+
+import androidx.credentials.CredentialManager
+import com.overdrive.cruiser.auth.GoogleAuthCredentials
+import com.overdrive.cruiser.auth.GoogleAuthProvider
+import com.overdrive.cruiser.auth.GoogleAuthProviderImpl
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal actual val platformCoreModule: Module = module {
+    factory { GoogleAuthCredentials("48643618736-o7920fcp7si1at4kl6b9pkl9dq3cbe93.apps.googleusercontent.com") }
+    factory { CredentialManager.create(androidContext()) } bind CredentialManager::class
+    singleOf(::GoogleAuthProviderImpl) bind GoogleAuthProvider::class
+}

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/auth/GoogleAuthCredentials.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/auth/GoogleAuthCredentials.kt
@@ -1,0 +1,3 @@
+package com.overdrive.cruiser.auth
+
+data class GoogleAuthCredentials(val serverId: String)

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/auth/GoogleAuthProvider.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/auth/GoogleAuthProvider.kt
@@ -1,0 +1,10 @@
+package com.overdrive.cruiser.auth
+
+import androidx.compose.runtime.Composable
+
+interface GoogleAuthProvider {
+    @Composable
+    fun getUiProvider(): GoogleAuthUiProvider
+
+    suspend fun signOut()
+}

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/auth/GoogleAuthUiProvider.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/auth/GoogleAuthUiProvider.kt
@@ -1,0 +1,9 @@
+package com.overdrive.cruiser.auth
+
+interface GoogleAuthUiProvider {
+    /**
+     * Opens Sign In with Google UI,
+     * @return returns GoogleUser
+     */
+    suspend fun signIn(): GoogleUser?
+}

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/auth/GoogleUser.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/auth/GoogleUser.kt
@@ -1,0 +1,7 @@
+package com.overdrive.cruiser.auth
+
+data class GoogleUser(
+    val idToken: String,
+    val displayName: String = "",
+    val profilePicUrl: String? = null,
+)

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/utils/KoinInit.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/utils/KoinInit.kt
@@ -1,0 +1,20 @@
+package com.overdrive.cruiser.utils
+
+import org.koin.core.context.startKoin
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+val appModule = module {
+    includes(platformCoreModule)
+}
+
+/**
+ * Initializes Koin, called from Swift
+ */
+fun initKoin() {
+    startKoin {
+        modules(appModule)
+    }
+}
+
+internal expect val platformCoreModule: Module

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/GoogleButtonUiContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/GoogleButtonUiContainer.kt
@@ -1,0 +1,40 @@
+package com.overdrive.cruiser.views
+
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import com.overdrive.cruiser.auth.GoogleAuthProvider
+import com.overdrive.cruiser.auth.GoogleUser
+import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
+
+interface GoogleButtonUiContainerScope {
+    fun onClick()
+}
+
+@Composable
+fun GoogleButtonUiContainer(
+    modifier: Modifier = Modifier,
+    onGoogleSignInResult: (GoogleUser?) -> Unit,
+    content: @Composable GoogleButtonUiContainerScope.() -> Unit,
+) {
+    val googleAuthProvider = koinInject<GoogleAuthProvider>()
+    val googleAuthUiProvider = googleAuthProvider.getUiProvider()
+    val coroutineScope = rememberCoroutineScope()
+    val uiContainerScope = remember {
+        object : GoogleButtonUiContainerScope {
+            override fun onClick() {
+                coroutineScope.launch {
+                    val googleUser = googleAuthUiProvider.signIn()
+                    onGoogleSignInResult(googleUser)
+                }
+            }
+        }
+    }
+    Surface(
+        modifier = modifier,
+        content = { uiContainerScope.content() }
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/LoginView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/LoginView.kt
@@ -1,0 +1,28 @@
+package com.overdrive.cruiser.views
+
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.overdrive.cruiser.auth.GoogleUser
+
+@Composable
+fun LoginView() {
+    var signedInUser: GoogleUser? by remember { mutableStateOf(null) }
+
+    GoogleButtonUiContainer(onGoogleSignInResult = { googleUser ->
+        val idToken= googleUser?.idToken
+        // TODO: Use the idToken to authenticate the user
+        signedInUser=googleUser
+    }) {
+        // TODO: Make a look like a Google Sign-In button
+        Button(
+            onClick = { this.onClick() }
+        ) {
+            Text("Sign-In with Google")
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/UserView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/UserView.kt
@@ -4,5 +4,5 @@ import androidx.compose.runtime.Composable
 
 @Composable
 fun UserView() {
-
+    LoginView()
 }

--- a/composeApp/src/iosMain/kotlin/com/overdrive/cruiser/auth/GoogleAuthProvider.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/overdrive/cruiser/auth/GoogleAuthProvider.ios.kt
@@ -1,0 +1,16 @@
+package com.overdrive.cruiser.auth
+
+import androidx.compose.runtime.Composable
+import cocoapods.GoogleSignIn.GIDSignIn
+import kotlinx.cinterop.ExperimentalForeignApi
+
+internal class GoogleAuthProviderImpl : GoogleAuthProvider {
+
+    @Composable
+    override fun getUiProvider(): GoogleAuthUiProvider = GoogleAuthUiProviderImpl()
+
+    @OptIn(ExperimentalForeignApi::class)
+    override suspend fun signOut() {
+        GIDSignIn.sharedInstance.signOut()
+    }
+}

--- a/composeApp/src/iosMain/kotlin/com/overdrive/cruiser/auth/GoogleAuthUiProvider.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/overdrive/cruiser/auth/GoogleAuthUiProvider.ios.kt
@@ -1,0 +1,32 @@
+package com.overdrive.cruiser.auth
+
+import cocoapods.GoogleSignIn.GIDSignIn
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.UIKit.UIApplication
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+internal class GoogleAuthUiProviderImpl : GoogleAuthUiProvider {
+    @OptIn(ExperimentalForeignApi::class)
+    override suspend fun signIn(): GoogleUser? = suspendCoroutine { continutation ->
+        val rootViewController =
+            UIApplication.sharedApplication.keyWindow?.rootViewController
+        if (rootViewController == null) continutation.resume(null)
+        else {
+            GIDSignIn.sharedInstance
+                .signInWithPresentingViewController(rootViewController) { gidSignInResult, nsError ->
+                    nsError?.let { println("Error While signing: $nsError") }
+                    val idToken = gidSignInResult?.user?.idToken?.tokenString
+                    val profile = gidSignInResult?.user?.profile
+                    if (idToken != null) {
+                        val googleUser = GoogleUser(
+                            idToken = idToken,
+                            displayName = profile?.name ?: "",
+                            profilePicUrl = profile?.imageURLWithDimension(320u)?.absoluteString
+                        )
+                        continutation.resume(googleUser)
+                    } else continutation.resume(null)
+                }
+        }
+    }
+}

--- a/composeApp/src/iosMain/kotlin/com/overdrive/cruiser/utils/KoinInit.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/overdrive/cruiser/utils/KoinInit.ios.kt
@@ -1,0 +1,12 @@
+package com.overdrive.cruiser.utils
+
+import com.overdrive.cruiser.auth.GoogleAuthProvider
+import com.overdrive.cruiser.auth.GoogleAuthProviderImpl
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+internal actual val platformCoreModule: Module = module {
+    singleOf(::GoogleAuthProviderImpl) bind GoogleAuthProvider::class
+}

--- a/composeApp/src/wasmJsMain/kotlin/com/overdrive/cruiser/utils/KoinInit.wasm.kt
+++ b/composeApp/src/wasmJsMain/kotlin/com/overdrive/cruiser/utils/KoinInit.wasm.kt
@@ -1,0 +1,7 @@
+package com.overdrive.cruiser.utils
+
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+internal actual val platformCoreModule: Module = module {
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,3 +9,6 @@ android.useAndroidX=true
 
 #Kotlin Multiplatform
 kotlin.mpp.enableCInteropCommonization=true
+
+kotlin.apple.deprecated.allowUsingEmbedAndSignWithCocoaPodsDependencies=true
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,9 @@ mapbox = "11.2.0"
 touchlab-skie = "0.9.0-RC.5"
 coroutines = "1.9.0"
 ktor = "3.0.0-rc-1"
+credentials = "1.3.0"
+google-id = "1.1.1"
+koin = "4.0.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -45,6 +48,13 @@ ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version
 ktor-client-serialization = { group = "io.ktor", name = "ktor-client-serialization", version.ref = "ktor" }
 ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
+androidx-credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }
+androidx-credentials-play-services-auth = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "credentials" }
+google-id = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "google-id" }
+koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koin" }
+koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin" }
+koin-compose-viewmodel-navigation = { module = "io.insert-koin:koin-compose-viewmodel-navigation", version.ref = "koin" }
+koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 
 [bundles]
 ktor-common = ["ktor-client-core", "ktor-client-json", "ktor-client-logging", "ktor-client-serialization", "ktor-client-content-negotiation", "ktor-serialization-kotlinx-json"]
@@ -57,3 +67,4 @@ compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 skie = { id = "co.touchlab.skie", version.ref = "touchlab-skie" }
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlinCocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
 		4036732C2CA330B100C30C77 /* MapSwiftView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4036732B2CA330B100C30C77 /* MapSwiftView.swift */; };
 		4036732F2CA331B200C30C77 /* MapboxMaps in Frameworks */ = {isa = PBXBuildFile; productRef = 4036732E2CA331B200C30C77 /* MapboxMaps */; };
+		40F016BD2CB0CE4C001E8687 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 40F016BC2CB0CE4C001E8687 /* GoogleSignIn */; };
+		40F016BF2CB0CE4C001E8687 /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 40F016BE2CB0CE4C001E8687 /* GoogleSignInSwift */; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
 /* End PBXBuildFile section */
 
@@ -31,7 +33,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				40F016BF2CB0CE4C001E8687 /* GoogleSignInSwift in Frameworks */,
 				4036732F2CA331B200C30C77 /* MapboxMaps in Frameworks */,
+				40F016BD2CB0CE4C001E8687 /* GoogleSignIn in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -111,6 +115,8 @@
 			name = iosApp;
 			packageProductDependencies = (
 				4036732E2CA331B200C30C77 /* MapboxMaps */,
+				40F016BC2CB0CE4C001E8687 /* GoogleSignIn */,
+				40F016BE2CB0CE4C001E8687 /* GoogleSignInSwift */,
 			);
 			productName = iosApp;
 			productReference = 7555FF7B242A565900829871 /* cruiser.app */;
@@ -143,6 +149,7 @@
 			mainGroup = 7555FF72242A565900829871;
 			packageReferences = (
 				4036732D2CA331B200C30C77 /* XCRemoteSwiftPackageReference "mapbox-maps-ios" */,
+				40F016BB2CB0CE4C001E8687 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 			);
 			productRefGroup = 7555FF7C242A565900829871 /* Products */;
 			projectDirPath = "";
@@ -406,6 +413,14 @@
 				minimumVersion = 11.0.0;
 			};
 		};
+		40F016BB2CB0CE4C001E8687 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/google/GoogleSignIn-iOS";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -413,6 +428,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 4036732D2CA331B200C30C77 /* XCRemoteSwiftPackageReference "mapbox-maps-ios" */;
 			productName = MapboxMaps;
+		};
+		40F016BC2CB0CE4C001E8687 /* GoogleSignIn */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 40F016BB2CB0CE4C001E8687 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
+			productName = GoogleSignIn;
+		};
+		40F016BE2CB0CE4C001E8687 /* GoogleSignInSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 40F016BB2CB0CE4C001E8687 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
+			productName = GoogleSignInSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -48,5 +48,18 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>GIDServerClientID</key>
+    <string>48643618736-o7920fcp7si1at4kl6b9pkl9dq3cbe93.apps.googleusercontent.com</string>
+    <key>GIDClientID</key>
+    <string>48643618736-bi9iq70hkfegaaki0dm247v01obsqbuu.apps.googleusercontent.com</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+      <dict>
+        <key>CFBundleURLSchemes</key>
+        <array>
+          <string>com.googleusercontent.apps.48643618736-bi9iq70hkfegaaki0dm247v01obsqbuu</string>
+        </array>
+      </dict>
+    </array>
 </dict>
 </plist>

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -1,9 +1,29 @@
 import SwiftUI
 import ComposeApp
+import GoogleSignIn
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+
+    func application(
+    _ app: UIApplication,
+    open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]
+    ) -> Bool {
+        var handled: Bool
+        
+        // Add any more custom url handles below
+        handled = GIDSignIn.sharedInstance.handle(url)
+
+        return handled
+    }
+}
 
 @main
 struct iOSApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
+    
     init() {
+        KoinInitKt.doInitKoin()
+        
         ViewFactoryKt.setViewFactories(
             mapWithSwiftViewFactory: mapWithSwiftViewFactory
         )
@@ -11,7 +31,9 @@ struct iOSApp: App {
     
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView().onOpenURL(perform: { url in
+                GIDSignIn.sharedInstance.handle(url)
+            })
         }
     }
 }


### PR DESCRIPTION
This PR adds Google Sign In on the client side for both Android and iOS.

Few things going on here:

- Converted our build to use `cocoapods` on iOS, as well as the Swift Package Manager. This is required to use GoogleSignIn on both Swift and Kotlin side.
- I added `Koin` which is a dependency injection library which simplifies the platform-specific classes here.

Other than that just login logic. I also didn't make the login button look pretty since someone will have to make the LoginView look nicer later anyways.

NOTE: This is just the first of a few PRs to handle login end-to-end. We still need to store the received token locally, and pass it off to the backend for verification. But this should be the most complicated PR.