### PR TITLE
add time filtering to map view

### DIFF
--- a/composeApp/src/commonMain/composeResources/drawable/filter.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/filter.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="32"
+    android:viewportHeight="32">
+  <path
+      android:pathData="M29.334,4H2.667L13.334,16.613V25.333L18.667,28V16.613L29.334,4Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3"
+      android:fillColor="#00000000"
+      android:strokeColor="#1E1E1E"
+      android:strokeLineCap="round"/>
+</vector>

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/models/MapViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/models/MapViewModel.kt
@@ -2,9 +2,6 @@ package com.overdrive.cruiser.models
 
 import com.overdrive.cruiser.endpoints.BookingEndpoint
 import com.overdrive.cruiser.endpoints.SpotFetcher
-import com.overdrive.cruiser.models.Booking
-import com.overdrive.cruiser.models.Coordinate
-import com.overdrive.cruiser.models.Spot
 import com.overdrive.cruiser.models.mapbox.Suggestion
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -28,6 +25,9 @@ class MapViewModel {
     private val _bookings = MutableStateFlow(emptyList<Booking>())
     val bookings: StateFlow<List<Booking>> = _bookings
 
+    private val _showFiltering = MutableStateFlow(false)
+    var showFiltering: StateFlow<Boolean> = _showFiltering
+
     fun updateCurrentLocation(location: Coordinate) {
         _currentLocation.value = location
     }
@@ -42,6 +42,10 @@ class MapViewModel {
 
     fun updateSelectedSpot(spot: Spot?) {
         _selectedSpot.value = spot
+    }
+
+    fun setShowFiltering(state: Boolean) {
+        _showFiltering.value = state
     }
 
     suspend fun updateSpots() {

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/DatePickerView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/DatePickerView.kt
@@ -1,7 +1,9 @@
 package com.overdrive.cruiser.views
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -23,37 +25,41 @@ import androidx.compose.ui.unit.dp
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DatePickerView(state: DatePickerState, onBack: () -> Unit) {
-    Column(modifier = Modifier.padding(16.dp)) {
-        DatePicker(
-            state = state,
-            colors = DatePickerDefaults.colors(
-                todayContentColor = Color.Black,
-                todayDateBorderColor = Color(0xFFF9784B),
-                selectedDayContainerColor = Color(0xFFF9784B),
-            ),
-            showModeToggle = false,
-            title = null,
-            headline = null
-        )
+    Column (Modifier.fillMaxSize().background(color = Color(0xFFF5F5F5))) {
+        SpotOnTopBar("Filter Spots") { onBack() }
 
-        SpotOnTimePicker(title = "Start Time")
+        Column(modifier = Modifier.padding(16.dp)) {
+            DatePicker(
+                state = state,
+                colors = DatePickerDefaults.colors(
+                    todayContentColor = Color.Black,
+                    todayDateBorderColor = Color(0xFFF9784B),
+                    selectedDayContainerColor = Color(0xFFF9784B),
+                ),
+                showModeToggle = false,
+                title = null,
+                headline = null
+            )
 
-        Spacer(modifier = Modifier.height(8.dp))
+            SpotOnTimePicker(title = "Start Time")
 
-        SpotOnTimePicker(title = "End Time")
+            Spacer(modifier = Modifier.height(8.dp))
 
-        Spacer(modifier = Modifier.weight(1f))
+            SpotOnTimePicker(title = "End Time")
 
-        Button(
-            onClick = { onBack() },
-            colors = ButtonDefaults.buttonColors(backgroundColor = Color(0xFFF9784B)),
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(55.dp)
-                .shadow(8.dp, RoundedCornerShape(12.dp))
-                .clip(RoundedCornerShape(12.dp))
-        ) {
-            Text("Submit", color = Color.White)
+            Spacer(modifier = Modifier.weight(1f))
+
+            Button(
+                onClick = { onBack() },
+                colors = ButtonDefaults.buttonColors(backgroundColor = Color(0xFFF9784B)),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(55.dp)
+                    .shadow(8.dp, RoundedCornerShape(12.dp))
+                    .clip(RoundedCornerShape(12.dp))
+            ) {
+                Text("Submit", color = Color.White)
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SearchSuggestionBoxView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SearchSuggestionBoxView.kt
@@ -6,9 +6,12 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldDefaults
@@ -25,7 +28,10 @@ import androidx.compose.ui.unit.dp
 import com.overdrive.cruiser.endpoints.SearchBoxFetcher
 import com.overdrive.cruiser.models.Coordinate
 import com.overdrive.cruiser.models.MapViewModel
+import cruiser.composeapp.generated.resources.Res
+import cruiser.composeapp.generated.resources.filter
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.vectorResource
 
 @Composable
 fun SearchSuggestionBoxView(modifier: Modifier, mapViewModel: MapViewModel) {
@@ -67,6 +73,16 @@ fun SearchSuggestionBoxView(modifier: Modifier, mapViewModel: MapViewModel) {
             ),
             shape = RoundedCornerShape(30.dp),
             interactionSource = remember { MutableInteractionSource() },
+            trailingIcon = {
+                IconButton(onClick = { mapViewModel.setShowFiltering(true) }) {
+                    Icon(
+                        imageVector = vectorResource(Res.drawable.filter),
+                        contentDescription = null,
+                        modifier = Modifier.size(35.dp).padding(end = 16.dp),
+                        tint = Color.Gray
+                    )
+                }
+            }
         )
 
         // Display search suggestions as a dropdown below the search bar

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SpotDetailView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SpotDetailView.kt
@@ -89,8 +89,6 @@ fun SpotDetailView(spot: Spot, onBack: () -> Unit) {
             if (visible) {
                 Column(modifier = Modifier.fillMaxSize().background(color = Color(0xFFF5F5F5))
                 ) {
-                    SpotOnTopBar("Select Date") { isDatePickerVisible = false }
-
                     DatePickerView(
                         state = datePickerState,
                         onBack = { isDatePickerVisible = false }

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SpotExplorerView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SpotExplorerView.kt
@@ -69,7 +69,7 @@ fun SpotExplorerView(mapViewModel: MapViewModel) {
                         slideOutHorizontally(targetOffsetX = { fullWidth -> fullWidth }) + fadeOut() using
                         SizeTransform(clip = false)
             }
-        ) {
+        ) { showFiltering ->
             if (showFiltering) {
                 DatePickerView(
                     state = datePickerState,

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SpotExplorerView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SpotExplorerView.kt
@@ -10,6 +10,8 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -20,10 +22,13 @@ import androidx.compose.ui.graphics.Color
 import com.overdrive.cruiser.models.MapViewModel
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SpotExplorerView(mapViewModel: MapViewModel) {
     val scope = rememberCoroutineScope()
     val selectedSpot by mapViewModel.selectedSpot.collectAsState()
+    val showFiltering by mapViewModel.showFiltering.collectAsState()
+    val datePickerState = rememberDatePickerState()
 
     Box {
         LaunchedEffect(selectedSpot){
@@ -47,6 +52,29 @@ fun SpotExplorerView(mapViewModel: MapViewModel) {
                     spot = spot,
                     onBack = {
                         mapViewModel.updateSelectedSpot(null)
+                        scope.launch {
+                            mapViewModel.updateSpots()
+                        }
+                    }
+                )
+            } else {
+                Box(modifier = Modifier.fillMaxSize().background(Color.Transparent))
+            }
+        }
+
+        AnimatedContent(
+            targetState = showFiltering,
+            transitionSpec = {
+                slideInHorizontally(initialOffsetX = { fullWidth -> fullWidth }) + fadeIn() togetherWith
+                        slideOutHorizontally(targetOffsetX = { fullWidth -> fullWidth }) + fadeOut() using
+                        SizeTransform(clip = false)
+            }
+        ) {
+            if (showFiltering) {
+                DatePickerView(
+                    state = datePickerState,
+                    onBack = {
+                        mapViewModel.setShowFiltering(false)
                         scope.launch {
                             mapViewModel.updateSpots()
                         }


### PR DESCRIPTION
This pr adds the time filtering for the map view. I added a filter icon in the search bar that will bring you to the filtering page on click. If we add more filters in the future, we'll probably want to create a new page that has its own button to access the date/time picker but this should work fine for now.

<img width="278" alt="image" src="https://github.com/user-attachments/assets/40510697-f5f7-418d-95cf-dfa0512483ae">
<img width="284" alt="image" src="https://github.com/user-attachments/assets/a705eb7b-a702-4e5e-b28f-7b2a3009a61a">
