### PR TITLE
add delete functionality for spots

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/endpoints/SpotFetcher.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/endpoints/SpotFetcher.kt
@@ -3,6 +3,7 @@ package com.overdrive.cruiser.endpoints
 import com.overdrive.cruiser.models.Spot
 import com.overdrive.cruiser.utils.requestGet
 import com.overdrive.cruiser.utils.requestPost
+import com.overdrive.cruiser.utils.requestDelete
 
 /**
  * Fetches spots from the server.
@@ -25,5 +26,10 @@ class SpotFetcher {
     suspend fun create(spot: Spot): Spot {
         val endpoint = "/spots"
         return requestPost(endpoint, spot)
+    }
+
+    suspend fun delete(spot: Spot) {
+        val endpoint = "/spots/${spot.id}"
+        val status = requestDelete(endpoint, spot)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/models/MySpotsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/models/MySpotsViewModel.kt
@@ -11,4 +11,8 @@ class MySpotsViewModel {
     suspend fun updateSpots() {
         _spots.value = SpotFetcher().fetch()
     }
+
+    suspend fun deleteSpot(spot: Spot) {
+        SpotFetcher().delete(spot)
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/utils/Request.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/utils/Request.kt
@@ -6,6 +6,7 @@ import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
@@ -44,4 +45,16 @@ suspend inline fun <reified R> requestPost(
         setBody(body)
     }
     return response.body()
+}
+
+suspend inline fun <reified R> requestDelete(
+    endpoint: String,
+    body: R,
+    baseUrl: String = BASE_URL
+): HttpStatusCode {
+    val response: HttpResponse = httpClient.delete(baseUrl + endpoint) {
+        contentType(ContentType.Application.Json)
+        setBody(body)
+    }
+    return response.status
 }

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/MySpotsView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/MySpotsView.kt
@@ -2,6 +2,7 @@ package com.overdrive.cruiser.views
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -23,6 +24,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -33,12 +38,16 @@ import com.overdrive.cruiser.models.MySpotsViewModel
 import cruiser.composeapp.generated.resources.Res
 import cruiser.composeapp.generated.resources.accessibility_on
 import cruiser.composeapp.generated.resources.weather_on
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.vectorResource
 
 @Composable
 fun MySpotsView(mySpotsViewModel: MySpotsViewModel, onAddSpotClick: () -> Unit) {
 
     val spots by mySpotsViewModel.spots.collectAsState()
+    val scope = rememberCoroutineScope()
+    var showDialog by remember { mutableStateOf(false) }
+    val spot = spots.firstOrNull { it.ownerId == "dev3" }
 
     Column {
         SpotOnTopBar("My Spot")
@@ -54,7 +63,6 @@ fun MySpotsView(mySpotsViewModel: MySpotsViewModel, onAddSpotClick: () -> Unit) 
                 .align(Alignment.Center)
                 .padding(16.dp)
             ) {
-                val spot = spots.firstOrNull { it.ownerId == "dev3" }
 
                 if (spot == null) {
                     Text(text = "No spots yet, add one!",
@@ -135,6 +143,31 @@ fun MySpotsView(mySpotsViewModel: MySpotsViewModel, onAddSpotClick: () -> Unit) 
                                 color = Color.White
                             )
                         }
+
+                        Spacer(modifier = Modifier.weight(1f))
+
+                        Button(
+                            onClick = {
+                                scope.launch {
+                                    showDialog = true
+                                }
+                            },
+                            shape = RoundedCornerShape(12.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                backgroundColor = Color.White,
+                            ),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(55.dp)
+                                .clip(RoundedCornerShape(12.dp))
+                                .border(2.dp, Color(0xFFF9784B), RoundedCornerShape(12.dp))
+                        ) {
+                            Text(
+                                text = "Delete Spot",
+                                color = Color(0xFFF9784B),
+                            )
+                        }
+
                     }
 
 
@@ -154,5 +187,21 @@ fun MySpotsView(mySpotsViewModel: MySpotsViewModel, onAddSpotClick: () -> Unit) 
                 }
             }
         }
+    }
+    if (showDialog) {
+        SpotOnAlertDialog(
+            "Confirm Deletion",
+            "Are you sure you want to delete this spot?",
+            onClick = {
+                scope.launch {
+                    spot?.let {
+                        mySpotsViewModel.deleteSpot(spot)
+                        mySpotsViewModel.updateSpots()
+                    }
+                    showDialog = false
+                }
+            },
+            onDismissRequest = { showDialog = false }
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SpotOnAlertDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SpotOnAlertDialog.kt
@@ -1,0 +1,46 @@
+package com.overdrive.cruiser.views
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SpotOnAlertDialog(title: String, text: String, onClick: () -> Unit, onDismissRequest: () -> Unit) {
+    AlertDialog(
+        modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(12.dp)),
+        backgroundColor = Color(0xFFF5F5F5),
+        shape = RoundedCornerShape(12.dp),
+        onDismissRequest = onDismissRequest,
+        title = { Text(title, fontWeight = FontWeight.Bold) },
+        text = { Text(text, color = Color.Black) },
+        confirmButton = {
+            Button(
+                onClick = onClick,
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = Color(0xFFF9784B),
+                ),
+            ) {
+                Text("Confirm", color = Color.White)
+            }
+        },
+        dismissButton = {
+            Button(
+                onClick = onDismissRequest,
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = Color(0xFFDDDDDD),
+                ),
+            ) {
+                Text("Cancel")
+            }
+        }
+    )
+}


### PR DESCRIPTION
Creates delete functionality for the frontend. Once users have a parking spot, the delete button will appear and they can click/confirm to delete the spot from the db.

<img width="283" alt="image" src="https://github.com/user-attachments/assets/2f88aa8c-3bd8-4be1-b843-370ae0a83eec">
<img width="279" alt="image" src="https://github.com/user-attachments/assets/f1961b0e-aa8a-41ea-98ec-5df14e263754">