### PR TITLE
create owner spot list and set default time

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/models/mapbox/DatePickerModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/models/mapbox/DatePickerModel.kt
@@ -1,0 +1,33 @@
+package com.overdrive.cruiser.models.mapbox
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.datetime.Clock
+
+class DatePickerModel {
+    private val _startHour = MutableStateFlow(0)
+    val startHour: StateFlow<Int> = _startHour
+
+    private val _startMinute = MutableStateFlow(0)
+    val startMinute: StateFlow<Int> = _startMinute
+
+    private val _endHour = MutableStateFlow(0)
+    val endHour: StateFlow<Int> = _endHour
+
+    private val _endMinute = MutableStateFlow(0)
+    val endMinute: StateFlow<Int> = _endMinute
+
+    private val _selectedDate = MutableStateFlow(Clock.System.now().toEpochMilliseconds())
+    val selectedDate: StateFlow<Long> = _selectedDate
+
+    fun updateSelectedTimes(startHour: Int, startMinute: Int, endHour: Int, endMinute: Int) {
+        _startHour.value = startHour
+        _startMinute.value = startMinute
+        _endHour.value = endHour
+        _endMinute.value = endMinute
+    }
+
+    fun updateSelectedDate(date: Long) {
+        _selectedDate.value = date
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/BookingsView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/BookingsView.kt
@@ -53,15 +53,15 @@ import org.jetbrains.compose.resources.painterResource
 
 
 @Composable
-fun BookingsView(savedSpotsViewModel: BookingsViewModel) {
-    val allBookings by savedSpotsViewModel.bookings.collectAsState()
+fun BookingsView(bookingsViewModel: BookingsViewModel) {
+    val allBookings by bookingsViewModel.bookings.collectAsState()
     val currentTime = remember { Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()) }
 
     val upcomingBookings = allBookings.filter { it.endTime > currentTime }
     val pastBookings = allBookings.filter { it.endTime < currentTime }
 
     LaunchedEffect(Unit) {
-        savedSpotsViewModel.updateBookings()
+        bookingsViewModel.updateBookings()
     }
 
     Column(
@@ -83,8 +83,8 @@ fun BookingsView(savedSpotsViewModel: BookingsViewModel) {
                 { selectedTab = it }
             ) { i -> selectedTab = i }
             when (selectedTab) {
-                    0 -> BookingList(upcomingBookings, savedSpotsViewModel, Color(0xFF006400))
-                    1 -> BookingList(pastBookings, savedSpotsViewModel, Color.LightGray)
+                    0 -> SpotOnSpotList(upcomingBookings, bookingsViewModel, Color(0xFF006400))
+                    1 -> SpotOnSpotList(pastBookings, bookingsViewModel, Color.LightGray)
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/DatePickerView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/DatePickerView.kt
@@ -13,8 +13,8 @@ import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Text
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDefaults
-import androidx.compose.material3.DatePickerState
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -22,7 +22,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.overdrive.cruiser.models.MapViewModel
+import com.overdrive.cruiser.models.mapbox.DatePickerModel
 import com.overdrive.cruiser.utils.TimeRange
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -30,13 +30,15 @@ import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Duration.Companion.days
-import kotlin.time.Duration.Companion.minutes
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun DatePickerView(state: DatePickerState, onBack: () -> Unit, onSelected: (TimeRange) -> Unit) {
-    val start = rememberTimePickerState(initialHour = 0, initialMinute = 0)
-    val end = rememberTimePickerState(initialHour = 0, initialMinute = 0)
+fun DatePickerView(datePickerModel: DatePickerModel, onBack: () -> Unit, onSelected: (TimeRange) -> Unit) {
+    val state = rememberDatePickerState(initialSelectedDateMillis = datePickerModel.selectedDate.value)
+    val start = rememberTimePickerState(initialHour = datePickerModel.startHour.value,
+        initialMinute = datePickerModel.startMinute.value)
+    val end = rememberTimePickerState(initialHour = datePickerModel.endHour.value,
+        initialMinute = datePickerModel.endMinute.value)
 
     Column (Modifier.fillMaxSize().background(color = Color(0xFFF5F5F5))) {
         SpotOnTopBar("Filter Spots") { onBack() }
@@ -69,6 +71,8 @@ fun DatePickerView(state: DatePickerState, onBack: () -> Unit, onSelected: (Time
                         combineDateAndTime(selectedDateMillis, start.hour, start.minute),
                         combineDateAndTime(selectedDateMillis, end.hour, end.minute)
                     )
+                    datePickerModel.updateSelectedTimes(start.hour, start.minute, end.hour, end.minute)
+                    datePickerModel.updateSelectedDate(selectedDateMillis)
                     onSelected(range)
                     onBack()
                },

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/NavigationBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/NavigationBar.kt
@@ -103,7 +103,7 @@ fun NavigationBar() {
             when (selectedScreen) {
                 Screen.Map -> SpotExplorerView(mapViewModel)
                 Screen.User -> UserView(userViewModel, onLogOut = { selectedScreen = Screen.Login })
-                Screen.MySpots -> MySpotsView(mySpotsViewModel) {
+                Screen.MySpots -> MySpotsView(mySpotsViewModel, bookingsViewModel) {
                     selectedScreen = Screen.AddSpot
                 }
                 Screen.Bookings -> BookingsView(bookingsViewModel)

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SearchSuggestionBoxView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SearchSuggestionBoxView.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
-import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SpotDetailView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SpotDetailView.kt
@@ -47,6 +47,7 @@ import com.overdrive.cruiser.endpoints.BookingEndpoint
 import com.overdrive.cruiser.models.Booking
 import com.overdrive.cruiser.models.BookingStatus
 import com.overdrive.cruiser.models.Spot
+import com.overdrive.cruiser.models.mapbox.DatePickerModel
 import com.overdrive.cruiser.utils.TimeRange
 import cruiser.composeapp.generated.resources.Res
 import cruiser.composeapp.generated.resources.accessibility_on
@@ -65,7 +66,7 @@ import kotlin.time.Duration.Companion.minutes
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SpotDetailView(spot: Spot, onBack: () -> Unit) {
+fun SpotDetailView(datePickerModel: DatePickerModel, spot: Spot, onBack: () -> Unit) {
     val scope = rememberCoroutineScope()
     val bookingEndpoint = BookingEndpoint()
     var isDatePickerVisible by remember { mutableStateOf(false) }
@@ -96,7 +97,7 @@ fun SpotDetailView(spot: Spot, onBack: () -> Unit) {
                 Column(modifier = Modifier.fillMaxSize().background(color = Color(0xFFF5F5F5))
                 ) {
                     DatePickerView(
-                        state = datePickerState,
+                        datePickerModel = datePickerModel,
                         onBack = { isDatePickerVisible = false },
                         onSelected = {
                             selectedTimeRange = it

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SpotExplorerView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SpotExplorerView.kt
@@ -12,8 +12,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -23,15 +21,15 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.overdrive.cruiser.models.MapViewModel
+import com.overdrive.cruiser.models.mapbox.DatePickerModel
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SpotExplorerView(mapViewModel: MapViewModel) {
     val scope = rememberCoroutineScope()
     val selectedSpot by mapViewModel.selectedSpot.collectAsState()
     val showFiltering by mapViewModel.showFiltering.collectAsState()
-    val datePickerState = rememberDatePickerState()
+    val datePickerModel = DatePickerModel()
 
     Box {
         LaunchedEffect(selectedSpot){
@@ -66,6 +64,7 @@ fun SpotExplorerView(mapViewModel: MapViewModel) {
         ) { spot ->
             if (spot != null) {
                 SpotDetailView(
+                    datePickerModel = datePickerModel,
                     spot = spot,
                     onBack = {
                         mapViewModel.updateSelectedSpot(null)
@@ -89,7 +88,7 @@ fun SpotExplorerView(mapViewModel: MapViewModel) {
         ) { showFiltering ->
             if (showFiltering) {
                 DatePickerView(
-                    state = datePickerState,
+                    datePickerModel = datePickerModel,
                     onBack = {
                         mapViewModel.setShowFiltering(false)
                         scope.launch {

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SpotOnSpotList.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SpotOnSpotList.kt
@@ -1,0 +1,143 @@
+package com.overdrive.cruiser.views
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.overdrive.cruiser.models.Booking
+import com.overdrive.cruiser.models.BookingsViewModel
+import com.overdrive.cruiser.models.Spot
+import cruiser.composeapp.generated.resources.Res
+import cruiser.composeapp.generated.resources.booking_image
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.painterResource
+
+@Composable
+fun SpotOnSpotList(spots: List<Spot>, color: Color, onClick: (Spot) -> Unit = {}) {
+    LazyColumn {
+        items(spots) { spot ->
+            SpotOnField(
+                Modifier
+                    .fillMaxWidth()
+                    .clickable { onClick(spot) }
+            ) {
+                SpotOnListItem(address = spot.address, color = color)
+            }
+        }
+    }
+}
+
+@Composable
+fun SpotOnSpotList(bookings: List<Booking>, viewModel: BookingsViewModel, color: Color,
+                   onClick: (Booking) -> Unit = {}) {
+    LazyColumn {
+        items(bookings) { booking ->
+            SpotOnField(
+                Modifier
+                    .fillMaxWidth()
+                    .clickable { onClick(booking) }
+            ) {
+                val scope = rememberCoroutineScope()
+                var spot by remember { mutableStateOf<Spot?>(null) }
+
+                LaunchedEffect(booking.parkingSpotId) {
+                    if (spot == null) {
+                        scope.launch {
+                            spot = viewModel.getSpotForBooking(booking.parkingSpotId)
+                        }
+                    }
+                }
+                SpotOnListItem(address = spot?.address ?: "...Fetching Address", color = color)
+            }
+        }
+    }
+}
+
+@Composable
+fun SpotOnListItem(address: String, color: Color) {
+    Box(
+        Modifier.drawBehind {
+            drawRect(
+                color = color,
+                topLeft = Offset(0f, 0f),
+                size = Size(64f, size.height)
+            )
+        }
+    ) {
+        Row(
+            Modifier.fillMaxWidth()
+        ) {
+            Image(
+                painter = painterResource(Res.drawable.booking_image),
+                contentDescription = "Photo of spot",
+                modifier = Modifier.padding(8.dp)
+            )
+
+            Spacer(modifier = Modifier.width(4.dp))
+
+            Column(
+                modifier = Modifier.fillMaxHeight(),
+                verticalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text("Summer House", fontWeight = FontWeight.Bold)
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = address,
+                    color = Color.Gray,
+                    style = TextStyle(fontSize = 12.sp),
+                    modifier = Modifier
+                        .width(192.dp)
+                        .padding(bottom = 8.dp),
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 2
+                )
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                contentDescription = "Right Arrow",
+                modifier = Modifier
+                    .padding(end = 8.dp)
+                    .size(36.dp)
+                    .align(Alignment.CenterVertically)
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SpotOnTimePicker.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SpotOnTimePicker.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -34,11 +35,11 @@ import org.jetbrains.compose.resources.vectorResource
 fun SpotOnTimePicker(timePickerState: TimePickerState, title: String, modifier: Modifier = Modifier) {
     var showTimePicker by remember { mutableStateOf(false) }
 
-    SpotOnField(modifier = modifier.fillMaxWidth()) {
+    SpotOnField(modifier = modifier.fillMaxWidth().height(65.dp)) {
         Row(modifier = modifier.padding(horizontal = 16.dp),
             verticalAlignment = Alignment.CenterVertically) {
 
-            Column(modifier = modifier.padding(bottom = 8.dp)) {
+            Column {
                 Text(text = title, fontSize = 12.sp, color = Color.Gray)
 
                 val selectedHour = timePickerState.hour


### PR DESCRIPTION
This pr has two features:
1. Added a model for the date picker to maintain the time set by filtering when you go to book a spot
2. Updated the my spots page to allow users to create more than one spot. There are two tab rows on this page, one which has the spots that are available at the current time the user is viewing them, and one which has the spots which are currently booked

Available tab:
<img width="270" alt="image" src="https://github.com/user-attachments/assets/38f7223c-db4c-4370-afd4-d44f3a85d470">

Booked tab:
<img width="274" alt="image" src="https://github.com/user-attachments/assets/51ec44d1-39c6-4c32-baa9-d94b0b560f6a">



