### PR TITLE
split app between owner and renter

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/LoginView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/LoginView.kt
@@ -1,11 +1,9 @@
 package com.overdrive.cruiser.views
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -24,19 +22,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.overdrive.cruiser.auth.GoogleUser
 import cruiser.composeapp.generated.resources.Res
 import cruiser.composeapp.generated.resources.apple_logo
 import cruiser.composeapp.generated.resources.facebook_logo
 import cruiser.composeapp.generated.resources.google_logo
-import cruiser.composeapp.generated.resources.house_image
+import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
 
 @Composable
@@ -55,133 +49,73 @@ fun LoginView(onAuthenticated: () -> Unit) {
         val onGoogleClick = { this.onClick() }
 
         Box(modifier = Modifier.fillMaxSize().background(Color.White)) {
-            Image(
-                painter = painterResource(Res.drawable.house_image),
-                contentDescription = null,
-                modifier = Modifier.fillMaxWidth()
-                    .align(Alignment.BottomCenter),
-                contentScale = ContentScale.Crop
-            )
+            SpotOnLoginBackground(modifier = Modifier.align(Alignment.BottomCenter))
 
-            Column(modifier = Modifier.fillMaxWidth()) {
-                Spacer(modifier = Modifier.height(140.dp))
+            Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
 
-                Text(
-                    text = "Connect",
-                    fontSize = 40.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = Color.Black,
-                    modifier = Modifier
-                        .padding(8.dp)
-                        .align(Alignment.Start),
+                SpotOnBranding(modifier = Modifier.align(Alignment.CenterHorizontally))
+
+                Spacer(modifier = Modifier.height(54.dp))
+
+                SpotOnLoginButton(
+                    platform = "Google",
+                    onClick = onGoogleClick,
+                    logo = Res.drawable.google_logo,
+                    iconModifier = Modifier.padding(start = 5.dp).size(50.dp)
                 )
 
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .fillMaxHeight()
-                        .clip(RoundedCornerShape(24.dp, 24.dp, 0.dp, 0.dp))
-                        .background(color = Color.Black.copy(alpha = 0.3f))
-                        .padding(24.dp),
-                ) {
-                    Button(
-                        onClick = { onGoogleClick() },
-                        shape = RoundedCornerShape(12.dp),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(55.dp)
-                            .shadow(elevation = 8.dp, shape = RoundedCornerShape(12.dp))
-                            .background(color = Color.White),
-                        colors = ButtonDefaults.buttonColors(
-                            backgroundColor = Color.White,
-                        ),
-                    ) {
-                        Box(
-                            modifier = Modifier.fillMaxWidth(),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Icon(
-                                painter = painterResource(Res.drawable.google_logo),
-                                contentDescription = null,
-                                tint = Color.Unspecified,
-                                modifier = Modifier
-                                    .align(Alignment.CenterStart)
-                                    .size(50.dp),
-                            )
-                            Text(
-                                text = "Continue With Google",
-                                color = contentColorFor(Color.Black),
-                            )
-                        }
-                    }
+                Spacer(modifier = Modifier.height(16.dp))
 
-                    Spacer(modifier = Modifier.height(16.dp))
+                SpotOnLoginButton(
+                    platform = "Apple",
+                    onClick = onGoogleClick,
+                    logo = Res.drawable.apple_logo,
+                    iconModifier = Modifier.padding(start = 11.dp)
+                )
 
-                    Button(
-                        onClick = { onGoogleClick() },
-                        shape = RoundedCornerShape(12.dp),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(55.dp)
-                            .shadow(elevation = 8.dp, shape = RoundedCornerShape(12.dp))
-                            .background(color = Color.White),
-                        colors = ButtonDefaults.buttonColors(
-                            backgroundColor = Color.White,
-                        ),
-                    ) {
-                        Box(
-                            modifier = Modifier.fillMaxWidth(),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Icon(
-                                painter = painterResource(Res.drawable.apple_logo),
-                                contentDescription = null,
-                                tint = Color.Unspecified,
-                                modifier = Modifier.align(Alignment.CenterStart)
-                                    .padding(start = 11.dp)
-                            )
+                Spacer(modifier = Modifier.height(16.dp))
 
-                            Text(
-                                text = "Continue With Apple",
-                                color = contentColorFor(Color.Black),
-                            )
-                        }
-                    }
-
-                    Spacer(modifier = Modifier.height(16.dp))
-
-                    Button(
-                        onClick = { onGoogleClick() },
-                        shape = RoundedCornerShape(12.dp),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(55.dp)
-                            .shadow(elevation = 8.dp, shape = RoundedCornerShape(12.dp))
-                            .background(color = Color.White),
-                        colors = ButtonDefaults.buttonColors(
-                            backgroundColor = Color.White,
-                        ),
-                    ) {
-                        Box(
-                            modifier = Modifier.fillMaxWidth(),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Icon(
-                                painter = painterResource(Res.drawable.facebook_logo),
-                                contentDescription = null,
-                                tint = Color.Unspecified,
-                                modifier = Modifier.align(Alignment.CenterStart)
-                                    .padding(start = 10.dp)
-                            )
-
-                            Text(
-                                text = "Continue With Facebook",
-                                color = contentColorFor(Color.Black),
-                            )
-                        }
-                    }
-                }
+                SpotOnLoginButton(
+                    platform = "Facebook",
+                    onClick = onGoogleClick,
+                    logo = Res.drawable.facebook_logo,
+                    iconModifier = Modifier.padding(start = 10.dp)
+                )
             }
+        }
+    }
+}
+
+@Composable
+fun SpotOnLoginButton(platform: String, onClick: () -> Unit, logo: DrawableResource,
+                      iconModifier: Modifier = Modifier) {
+    Button(
+        onClick = onClick,
+        shape = RoundedCornerShape(12.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(55.dp)
+            .shadow(elevation = 8.dp, shape = RoundedCornerShape(12.dp)),
+        colors = ButtonDefaults.buttonColors(
+            backgroundColor = Color.LightGray,
+        ),
+    ) {
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                painter = painterResource(logo),
+                contentDescription = null,
+                tint = Color.Unspecified,
+                modifier = iconModifier.align(Alignment.CenterStart)
+                    .padding(start = 11.dp)
+            )
+
+            Text(
+                text = "Continue With $platform",
+                color = contentColorFor(Color.Black),
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/NavigationBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/NavigationBar.kt
@@ -30,7 +30,7 @@ import org.jetbrains.compose.resources.vectorResource
  * The different screens that can be displayed in the app.
  */
 enum class Screen {
-    Map, User, MySpots, Bookings, AddSpot, GetStarted, Login, Terms
+    Map, User, MySpots, Bookings, AddSpot, GetStarted, UserType, Login, Terms
 }
 
 /**
@@ -39,11 +39,12 @@ enum class Screen {
 @Composable
 fun NavigationBar() {
     var selectedScreen by remember { mutableStateOf(Screen.GetStarted) }
-    var noNavBarScreens = listOf(Screen.GetStarted, Screen.Login, Screen.Terms)
+    var noNavBarScreens = listOf(Screen.GetStarted, Screen.UserType, Screen.Login, Screen.Terms)
     val mapViewModel = remember { MapViewModel() }
     val userViewModel = remember { UserViewModel() }
     val mySpotsViewModel = remember { MySpotsViewModel() }
     val bookingsViewModel = remember { BookingsViewModel() }
+    var userType by remember { mutableStateOf("") }
 
     Scaffold(
         bottomBar = {
@@ -60,30 +61,33 @@ fun NavigationBar() {
                         selected = selectedScreen == Screen.Map,
                         onClick = { selectedScreen = Screen.Map }
                     )
-                    BottomNavigationItem(
-                        icon = {
-                            Image(
-                                modifier = Modifier.size(20.dp),
-                                imageVector = vectorResource(Res.drawable.saved_spots),
-                                contentDescription = null
-                            )
-                        },
-                        label = { Text("Bookings") },
-                        selected = selectedScreen == Screen.Bookings,
-                        onClick = { selectedScreen = Screen.Bookings }
-                    )
-                    BottomNavigationItem(
-                        icon = {
-                            Image(
-                                modifier = Modifier.size(20.dp),
-                                imageVector = vectorResource(Res.drawable.my_spots),
-                                contentDescription = null
-                            )
-                        },
-                        label = { Text("My Spots") },
-                        selected = selectedScreen == Screen.MySpots,
-                        onClick = { selectedScreen = Screen.MySpots }
-                    )
+                    if (userType == "Owner") {
+                        BottomNavigationItem(
+                            icon = {
+                                Image(
+                                    modifier = Modifier.size(20.dp),
+                                    imageVector = vectorResource(Res.drawable.my_spots),
+                                    contentDescription = null
+                                )
+                            },
+                            label = { Text("My Spots") },
+                            selected = selectedScreen == Screen.MySpots,
+                            onClick = { selectedScreen = Screen.MySpots }
+                        )
+                    } else {
+                        BottomNavigationItem(
+                            icon = {
+                                Image(
+                                    modifier = Modifier.size(20.dp),
+                                    imageVector = vectorResource(Res.drawable.saved_spots),
+                                    contentDescription = null
+                                )
+                            },
+                            label = { Text("Bookings") },
+                            selected = selectedScreen == Screen.Bookings,
+                            onClick = { selectedScreen = Screen.Bookings }
+                        )
+                    }
                     BottomNavigationItem(
                         icon = { Icon(Icons.Default.Person, contentDescription = null) },
                         label = { Text("User") },
@@ -102,7 +106,7 @@ fun NavigationBar() {
         ) {
             when (selectedScreen) {
                 Screen.Map -> SpotExplorerView(mapViewModel)
-                Screen.User -> UserView(userViewModel, onLogOut = { selectedScreen = Screen.Login })
+                Screen.User -> UserView(userViewModel, onLogOut = { selectedScreen = Screen.GetStarted })
                 Screen.MySpots -> MySpotsView(mySpotsViewModel, bookingsViewModel) {
                     selectedScreen = Screen.AddSpot
                 }
@@ -112,7 +116,8 @@ fun NavigationBar() {
                     onSpotAdded = { selectedScreen = Screen.MySpots },
                     addSpotViewModel = AddSpotViewModel()
                 )
-                Screen.GetStarted -> GetStartedView { selectedScreen = Screen.Login }
+                Screen.GetStarted -> GetStartedView { selectedScreen = Screen.UserType }
+                Screen.UserType -> UserTypeView { userType = it; selectedScreen = Screen.Login }
                 Screen.Login -> LoginView { selectedScreen = Screen.Terms }
                 Screen.Terms -> TermsView { selectedScreen = Screen.Map }
             }

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SpotOnLoginBranding.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SpotOnLoginBranding.kt
@@ -1,0 +1,59 @@
+package com.overdrive.cruiser.views
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import cruiser.composeapp.generated.resources.Res
+import cruiser.composeapp.generated.resources.house_image
+import cruiser.composeapp.generated.resources.spot_on_logo
+import org.jetbrains.compose.resources.painterResource
+
+@Composable
+fun SpotOnLoginBackground(modifier: Modifier = Modifier) {
+    Box(modifier = modifier) {
+        Image(
+            painter = painterResource(Res.drawable.house_image),
+            contentDescription = null,
+            modifier = modifier.fillMaxWidth()
+                .align(Alignment.BottomCenter),
+            contentScale = ContentScale.Crop
+        )
+    }
+}
+
+
+@Composable
+fun SpotOnBranding(modifier: Modifier = Modifier) {
+    Column(modifier = modifier) {
+        Box(
+            modifier = modifier
+                .align(Alignment.CenterHorizontally)
+                .height(150.dp)
+                .padding(16.dp, 80.dp, 16.dp, 0.dp)
+        ) {
+            Image(
+                painter = painterResource(Res.drawable.spot_on_logo),
+                contentDescription = null,
+                modifier = Modifier.size(200.dp),
+            )
+        }
+
+        Text(
+            "The Parking Revolution",
+            fontSize = 20.sp,
+            modifier = modifier
+                .align(Alignment.CenterHorizontally)
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/TermsView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/TermsView.kt
@@ -1,12 +1,10 @@
 package com.overdrive.cruiser.views
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -18,90 +16,60 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import cruiser.composeapp.generated.resources.Res
-import cruiser.composeapp.generated.resources.house_image
-import org.jetbrains.compose.resources.painterResource
 
 @Composable
 fun TermsView(onAgree: () -> Unit) {
     Box(modifier = Modifier.fillMaxSize().background(Color.White)) {
-        Image(
-            painter = painterResource(Res.drawable.house_image),
-            contentDescription = null,
-            modifier = Modifier.fillMaxWidth()
-                .align(Alignment.BottomCenter),
-            contentScale = ContentScale.Crop
-        )
 
+        SpotOnLoginBackground(modifier = Modifier.align(Alignment.BottomCenter))
 
-        Column(modifier = Modifier.fillMaxWidth(),
+        Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally) {
 
-            Spacer(modifier = Modifier.height(140.dp))
+            SpotOnBranding(Modifier.align(Alignment.CenterHorizontally))
 
-            Text(
-                text = "Terms of Service",
-                fontSize = 40.sp,
-                fontWeight = FontWeight.Bold,
-                color = Color.Black,
-                modifier = Modifier
-                    .padding(8.dp)
-                    .align(Alignment.Start),
-            )
+            Spacer(modifier = Modifier.height(54.dp))
 
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .fillMaxHeight()
-                    .clip(RoundedCornerShape(24.dp, 24.dp, 0.dp, 0.dp))
-                    .background(color = Color.Black.copy(alpha = 0.3f))
-                    .padding(24.dp),
-            ) {
-                Box (modifier = Modifier.padding(16.dp)) {
-                    Text(
-                        text = AnnotatedString.Builder().apply {
-                            append("By selecting Agree and continue below, I agree to ")
-                            withStyle(style = SpanStyle(color = Color(0xFFF9784B))) {
-                                append("Terms of Service")
-                            }
-                            append(" and ")
-                            withStyle(style = SpanStyle(color = Color(0xFFF9784B))) {
-                                append("Privacy Policy.")
-                            }
-                        }.toAnnotatedString(),
-                        color = Color.White
-                    )
-                }
 
-                Button(
-                    onClick = { onAgree() },
-                    shape = RoundedCornerShape(12.dp),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(55.dp)
-                        .shadow(elevation = 8.dp, shape = RoundedCornerShape(12.dp)),
-                    colors = ButtonDefaults.buttonColors(
-                        backgroundColor = Color(0xFFF9784B),
-                    ),
-                ) {
-                    Text(
-                        text = "Agree and Continue",
-                        color = Color.White,
-                    )
-                }
+            Box(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    text = AnnotatedString.Builder().apply {
+                        append("By selecting Agree and continue below, I agree to ")
+                        withStyle(style = SpanStyle(color = Color(0xFFF9784B))) {
+                            append("Terms of Service")
+                        }
+                        append(" and ")
+                        withStyle(style = SpanStyle(color = Color(0xFFF9784B))) {
+                            append("Privacy Policy.")
+                        }
+                    }.toAnnotatedString(),
+                    color = Color.Black
+                )
             }
 
+            Button(
+                onClick = { onAgree() },
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(55.dp)
+                    .shadow(elevation = 8.dp, shape = RoundedCornerShape(12.dp)),
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = Color(0xFFF9784B),
+                ),
+            ) {
+                Text(
+                    text = "Agree and Continue",
+                    color = Color.White,
+                )
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/UserTypeView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/UserTypeView.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun GetStartedView(onGetStartedClick: () -> Unit) {
+fun UserTypeView(onUserTypeClick: (String) -> Unit) {
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -37,7 +37,7 @@ fun GetStartedView(onGetStartedClick: () -> Unit) {
             Spacer(modifier = Modifier.height(54.dp))
 
             Button(
-                onClick = { onGetStartedClick() },
+                onClick = { onUserTypeClick("Renter") },
                 colors = ButtonDefaults.buttonColors(backgroundColor = Color(0xFFF9784B)),
                 modifier = Modifier
                     .fillMaxWidth()
@@ -45,18 +45,21 @@ fun GetStartedView(onGetStartedClick: () -> Unit) {
                     .shadow(8.dp, RoundedCornerShape(12.dp))
                     .clip(RoundedCornerShape(12.dp))
             ) {
-                Text("Get Started", color = Color.White)
+                Text("I Am a Renter", color = Color.White)
             }
 
+            Spacer(modifier = Modifier.height(16.dp))
+
             Button(
-                onClick = { onGetStartedClick() },
-                colors = ButtonDefaults.buttonColors(Color.Transparent),
-                elevation = null,
+                onClick = { onUserTypeClick("Owner") },
+                colors = ButtonDefaults.buttonColors(backgroundColor = Color.LightGray),
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(55.dp)
+                    .shadow(8.dp, RoundedCornerShape(12.dp))
+                    .clip(RoundedCornerShape(12.dp))
             ) {
-                Text("Already have an account", color = Color(0xFFF9784B))
+                Text("I Am an Owner", color = Color.Black)
             }
         }
 


### PR DESCRIPTION
Added a page on the login view to choose between account types (owner and renter). Based on the selection of the user, they will be shown either bookings (for renter) or my spots (for owner) on the navigation bar. Also updated the UI of the login pages to be more cohesive and include branding.

<img width="365" alt="image" src="https://github.com/user-attachments/assets/68ba005d-9266-4a41-b283-2bdb9809e0b8">
<img width="368" alt="image" src="https://github.com/user-attachments/assets/3cf1b197-e404-4cf7-be06-b1c9dc6cdf89">
<img width="376" alt="image" src="https://github.com/user-attachments/assets/a242d5e2-8683-431f-a08b-4d7678904e47">
<img width="381" alt="image" src="https://github.com/user-attachments/assets/efd2a3c2-b28b-4699-90ff-9e527eb90474">

Renter View:
<img width="369" alt="image" src="https://github.com/user-attachments/assets/b310d883-67b4-4690-b776-d1805be37466">

Owner View:
<img width="361" alt="image" src="https://github.com/user-attachments/assets/e6febe13-960f-4081-a1d7-700c60ce0303">
