### PR TITLE
add navigation to the login pages

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/LoginView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/LoginView.kt
@@ -13,8 +13,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material.Text
 import androidx.compose.material.contentColorFor
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -34,7 +38,7 @@ import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
 
 @Composable
-fun LoginView(onAuthenticated: () -> Unit) {
+fun LoginView(onAuthenticated: () -> Unit, onBackClick: () -> Unit) {
     var signedInUser: GoogleUser? by remember { mutableStateOf(null) }
 
     GoogleButtonUiContainer(onGoogleSignInResult = { googleUser ->
@@ -50,6 +54,15 @@ fun LoginView(onAuthenticated: () -> Unit) {
 
         Box(modifier = Modifier.fillMaxSize().background(Color.White)) {
             SpotOnLoginBackground(modifier = Modifier.align(Alignment.BottomCenter))
+
+            IconButton(
+                onClick = onBackClick,
+                modifier = Modifier.padding(16.dp).size(24.dp).align(Alignment.TopStart),
+            ) {
+                Icon(Icons.AutoMirrored.Outlined.ArrowBack,
+                    contentDescription = "Back"
+                )
+            }
 
             Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
 

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/NavigationBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/NavigationBar.kt
@@ -39,7 +39,7 @@ enum class Screen {
 @Composable
 fun NavigationBar() {
     var selectedScreen by remember { mutableStateOf(Screen.GetStarted) }
-    var noNavBarScreens = listOf(Screen.GetStarted, Screen.UserType, Screen.Login, Screen.Terms)
+    val noNavBarScreens = listOf(Screen.GetStarted, Screen.UserType, Screen.Login, Screen.Terms)
     val mapViewModel = remember { MapViewModel() }
     val userViewModel = remember { UserViewModel() }
     val mySpotsViewModel = remember { MySpotsViewModel() }
@@ -117,9 +117,12 @@ fun NavigationBar() {
                     addSpotViewModel = AddSpotViewModel()
                 )
                 Screen.GetStarted -> GetStartedView { selectedScreen = Screen.UserType }
-                Screen.UserType -> UserTypeView { userType = it; selectedScreen = Screen.Login }
-                Screen.Login -> LoginView { selectedScreen = Screen.Terms }
-                Screen.Terms -> TermsView { selectedScreen = Screen.Map }
+                Screen.UserType -> UserTypeView({ userType = it; selectedScreen = Screen.Login },
+                    { selectedScreen = Screen.GetStarted })
+                Screen.Login -> LoginView({ selectedScreen = Screen.Terms },
+                    { selectedScreen = Screen.UserType })
+                Screen.Terms -> TermsView({ selectedScreen = Screen.Map },
+                    { selectedScreen = Screen.Login })
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/TermsView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/TermsView.kt
@@ -9,10 +9,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Icon
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,10 +29,20 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun TermsView(onAgree: () -> Unit) {
+fun TermsView(onAgree: () -> Unit, onBackClick: () -> Unit) {
     Box(modifier = Modifier.fillMaxSize().background(Color.White)) {
 
         SpotOnLoginBackground(modifier = Modifier.align(Alignment.BottomCenter))
+
+        IconButton(
+            onClick = onBackClick,
+            modifier = Modifier.padding(16.dp).size(24.dp).align(Alignment.TopStart),
+        ) {
+            Icon(
+                Icons.AutoMirrored.Outlined.ArrowBack,
+                contentDescription = "Back"
+            )
+        }
 
         Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
             verticalArrangement = Arrangement.Center,

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/UserTypeView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/UserTypeView.kt
@@ -8,10 +8,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Icon
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -21,12 +26,22 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun UserTypeView(onUserTypeClick: (String) -> Unit) {
+fun UserTypeView(onUserTypeClick: (String) -> Unit, onBackClick: () -> Unit) {
     Box(
         modifier = Modifier
             .fillMaxSize()
             .background(Color.White)
     ) {
+        IconButton(
+            onClick = onBackClick,
+            modifier = Modifier.padding(16.dp).size(24.dp).align(Alignment.TopStart),
+        ) {
+            Icon(
+                Icons.AutoMirrored.Outlined.ArrowBack,
+                contentDescription = "Back"
+            )
+        }
+
         Column(
             modifier = Modifier
                 .fillMaxWidth()


### PR DESCRIPTION
Adds a back arrow to the last three login pages so users can navigate back to the previous page.

<img width="273" alt="image" src="https://github.com/user-attachments/assets/ee89f222-7272-4fbe-ac4d-5cbd5103d96c">
