### PR TITLE
add in batching for spot creation

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/models/AddSpotViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/models/AddSpotViewModel.kt
@@ -2,6 +2,7 @@ package com.overdrive.cruiser.models
 
 import com.overdrive.cruiser.endpoints.SpotFetcher
 import com.overdrive.cruiser.models.mapbox.Suggestion
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -18,6 +19,9 @@ class AddSpotViewModel {
     private val _spots = MutableStateFlow(emptyList<Spot>())
     val spots: StateFlow<List<Spot>> = _spots
 
+    private val _selectedAddress = MutableStateFlow("dev spot")
+    val selectedAddress: StateFlow<String> = _selectedAddress
+
     fun updateCurrentLocation(location: Coordinate) {
         _currentLocation.value = location
     }
@@ -28,6 +32,10 @@ class AddSpotViewModel {
 
     fun updateSuggestions(suggestions: List<Suggestion>) {
         _suggestions.value = suggestions
+    }
+
+    fun updateSelectedAddress(address: String) {
+        _selectedAddress.value = address
     }
 
     suspend fun createSpot(spot: Spot) {

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/AddSpotView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/AddSpotView.kt
@@ -2,11 +2,13 @@ package com.overdrive.cruiser.views
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -14,14 +16,18 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.IconToggleButton
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material3.RangeSlider
+import androidx.compose.material3.SliderDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -35,6 +41,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.overdrive.cruiser.endpoints.SearchBoxFetcher
@@ -48,8 +57,8 @@ import cruiser.composeapp.generated.resources.accessibility_on
 import cruiser.composeapp.generated.resources.weather_off
 import cruiser.composeapp.generated.resources.weather_on
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.vectorResource
-
 
 @Composable
 fun AddSpotView(onBackClick: () -> Unit, onSpotAdded: () -> Unit, addSpotViewModel: AddSpotViewModel) {
@@ -58,19 +67,20 @@ fun AddSpotView(onBackClick: () -> Unit, onSpotAdded: () -> Unit, addSpotViewMod
     var dollarsADay by remember { mutableStateOf("0.0") }
     var accessible by remember { mutableStateOf(true) }
     var sheltered by remember { mutableStateOf(true) }
-    var searchedSuggestion = remember { mutableStateOf<Suggestion?>(null) }
 
-    val suggestions by addSpotViewModel.suggestions.collectAsState()
-    val query by addSpotViewModel.query.collectAsState()
+    var buildingTypeExpanded by remember { mutableStateOf(false) }
+    val buildingTypes = listOf("House", "Apartment", "Condo", "Other")
+    var selectedBuildingType by remember { mutableStateOf(buildingTypes.first()) }
+    var spotNumbers by remember { mutableStateOf("1") }
     val currentLocation by addSpotViewModel.currentLocation.collectAsState()
-    val suggestionGenerator = remember { SearchBoxFetcher() }
-    val focusManager = LocalFocusManager.current
+    val selectedAddress by addSpotViewModel.selectedAddress.collectAsState()
 
-    Column(modifier = Modifier.fillMaxWidth().background(color = Color(0xFFF5F5F5))) {
+    Column(modifier = Modifier
+        .fillMaxSize().background(color = Color(0xFFF5F5F5))
+    ) {
         SpotOnTopBar("Add Spot", onBackClick)
 
-        Column(modifier = Modifier.padding(16.dp)) {
-
+        Column(modifier = Modifier.padding(16.dp).verticalScroll(rememberScrollState())) {
             Box(
                 modifier = Modifier
                     .height(55.dp)
@@ -86,47 +96,21 @@ fun AddSpotView(onBackClick: () -> Unit, onSpotAdded: () -> Unit, addSpotViewMod
 
                     Spacer(modifier = Modifier.weight(1f))
 
-                    IconToggleButton(
+                    SpotOnIconToggle(
                         checked = sheltered,
+                        iconOn = Res.drawable.weather_on,
+                        iconOff = Res.drawable.weather_off,
                         onCheckedChange = { newState ->
                             sheltered = newState
-                        },
-                        content = {
-                            if (sheltered) {
-                                Image(
-                                    modifier = Modifier.size(17.dp),
-                                    imageVector = vectorResource(Res.drawable.accessibility_on),
-                                    contentDescription = null
-                                )
-                            } else {
-                                Image(
-                                    modifier = Modifier.size(17.dp),
-                                    imageVector = vectorResource(Res.drawable.accessibility_off),
-                                    contentDescription = null
-                                )
-                            }
                         }
                     )
 
-                    IconToggleButton(
+                    SpotOnIconToggle(
                         checked = accessible,
+                        iconOn = Res.drawable.accessibility_on,
+                        iconOff = Res.drawable.accessibility_off,
                         onCheckedChange = { newState ->
                             accessible = newState
-                        },
-                        content = {
-                            if (accessible) {
-                                Image(
-                                    modifier = Modifier.size(17.dp),
-                                    imageVector = vectorResource(Res.drawable.weather_on),
-                                    contentDescription = null
-                                )
-                            } else {
-                                Image(
-                                    modifier = Modifier.size(17.dp),
-                                    imageVector = vectorResource(Res.drawable.weather_off),
-                                    contentDescription = null
-                                )
-                            }
                         }
                     )
                 }
@@ -135,119 +119,100 @@ fun AddSpotView(onBackClick: () -> Unit, onSpotAdded: () -> Unit, addSpotViewMod
             Spacer(modifier = Modifier.height(8.dp))
 
             Row {
-                TextField(
-                    label = { Text("Add $/hour") },
+                SpotOnTextField(
+                    label = "Add $/hour",
                     value = dollarsAnHour,
                     onValueChange = { dollarsAnHour = it },
-                    colors = TextFieldDefaults.textFieldColors(
-                        unfocusedIndicatorColor = Color.Transparent,
-                        focusedIndicatorColor = Color.Transparent,
-                        backgroundColor = Color.White,
-                        cursorColor = Color.Gray,
-                        focusedLabelColor = Color.DarkGray,
-                        unfocusedLabelColor = Color.Gray,
-                        textColor = Color.DarkGray
-                    ),
                     modifier = Modifier
                         .height(55.dp)
                         .weight(0.45f)
                         .shadow(8.dp, RoundedCornerShape(12.dp))
                         .background(color = Color.White, shape = RoundedCornerShape(12.dp))
                         .clip(RoundedCornerShape(12.dp))
-
                 )
 
                 Spacer(modifier = Modifier.width(8.dp))
 
-                TextField(
-                    label = { Text("Add $/day") },
+                SpotOnTextField(
+                    label = "Add $/day",
                     value = dollarsADay,
                     onValueChange = { dollarsADay = it },
-                    colors = TextFieldDefaults.textFieldColors(
-                        unfocusedIndicatorColor = Color.Transparent,
-                        focusedIndicatorColor = Color.Transparent,
-                        backgroundColor = Color.White,
-                        cursorColor = Color.Gray,
-                        focusedLabelColor = Color.DarkGray,
-                        unfocusedLabelColor = Color.Gray,
-                        textColor = Color.DarkGray
-                    ),
                     modifier = Modifier
                         .height(55.dp)
                         .weight(0.45f)
                         .shadow(8.dp, RoundedCornerShape(12.dp))
                         .background(color = Color.White, shape = RoundedCornerShape(12.dp))
                         .clip(RoundedCornerShape(12.dp))
-
                 )
             }
 
             Spacer(modifier = Modifier.height(8.dp))
 
-            Column() {
-                TextField(
-                    label = { Text("Add Address") },
-                    value = query,
-                    onValueChange = {
-                        addSpotViewModel.updateQuery(it)
-                        if (it.trim().isNotEmpty()) {
-                            scope.launch {
-                                addSpotViewModel.updateSuggestions(
-                                    suggestionGenerator.fetch(it)
-                                )
-                            }
-                        }
-                    },
-                    colors = TextFieldDefaults.textFieldColors(
-                        unfocusedIndicatorColor = Color.Transparent,
-                        focusedIndicatorColor = Color.Transparent,
-                        backgroundColor = Color.White,
-                        cursorColor = Color.Gray,
-                        focusedLabelColor = Color.DarkGray,
-                        unfocusedLabelColor = Color.Gray,
-                        textColor = Color.DarkGray
-                    ),
+            AddSpotSearchBox(addSpotViewModel)
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Column {
+                Box(
                     modifier = Modifier
-                        .fillMaxWidth()
                         .height(55.dp)
-                        .shadow(8.dp, RoundedCornerShape(12.dp))
+                        .shadow(12.dp, RoundedCornerShape(12.dp))
                         .background(color = Color.White, shape = RoundedCornerShape(12.dp))
                         .clip(RoundedCornerShape(12.dp))
-                )
-
-                LazyColumn(
-                    modifier = Modifier.fillMaxWidth()
-                        .shadow(8.dp, RoundedCornerShape(12.dp))
-                        .background(Color.White)
-                        .clip(RoundedCornerShape(12.dp))
                 ) {
-                    items(suggestions) { suggestion ->
-                        Text(
-                            text = suggestion.name,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(8.dp)
-                                .clickable {
-                                    scope.launch {
-                                        suggestionGenerator.fetch(suggestion)?.let { feature ->
-                                            addSpotViewModel.updateCurrentLocation(
-                                                Coordinate(
-                                                    feature.geometry.coordinates[0],
-                                                    feature.geometry.coordinates[1]
-                                                )
-                                            )
-                                        }
-                                    }
-                                    focusManager.clearFocus()
-                                    addSpotViewModel.updateQuery(suggestion.name)
-                                    addSpotViewModel.updateSuggestions(emptyList())
-                                    searchedSuggestion.value = suggestion
-                                },
-                            color = Color.DarkGray,
-                        )
+                    Row(
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                            .clickable(onClick = { buildingTypeExpanded = !buildingTypeExpanded }),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column {
+                            Text("Building Type", fontSize = 12.sp, color = Color.Gray)
+                            Text(selectedBuildingType)
+                        }
+
+                        Spacer(modifier = Modifier.weight(1f))
+
+                        Text("▼", color = Color.Gray)
+                    }
+                }
+
+                if (buildingTypeExpanded) {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxWidth()
+                            .shadow(8.dp, RoundedCornerShape(12.dp))
+                            .height(165.dp)
+                            .background(Color.White)
+                            .clip(RoundedCornerShape(12.dp))
+                    ) {
+                        items(buildingTypes) { buildingType ->
+                            Text(
+                                text = buildingType,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                                    .clickable {
+                                        selectedBuildingType = buildingType
+                                        buildingTypeExpanded = false
+                                    },
+                                color = Color.DarkGray
+                            )
+                        }
                     }
                 }
             }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            SpotOnTextField(
+                label = "Add Spot Number(s), Ex. 1,4-6",
+                value = spotNumbers,
+                onValueChange = { spotNumbers = it },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            SpotOnSelectAvailability()
 
             Spacer(modifier = Modifier.height(16.dp))
 
@@ -310,12 +275,21 @@ fun AddSpotView(onBackClick: () -> Unit, onSpotAdded: () -> Unit, addSpotViewMod
 
             Button(
                 onClick = {
-                    val address = searchedSuggestion.value?.name ?: "dev spot"
-                    val spot = Spot("999", "dev3", address, currentLocation.longitude, currentLocation.latitude)
-                    scope.launch {
-                        addSpotViewModel.createSpot(spot)
+                    val createdSpotNumbers = parseNumberRange(spotNumbers)
+
+                    for (spotNumber in createdSpotNumbers) {
+                        val spot = Spot(
+                            "999", "dev3", "$selectedAddress $spotNumber",
+                            currentLocation.longitude, currentLocation.latitude
+                        )
+
+                        scope.launch {
+                            addSpotViewModel.createSpot(spot)
+                        }
                     }
-                    onSpotAdded() },
+
+                    onSpotAdded()
+                },
                 colors = ButtonDefaults.buttonColors(backgroundColor = Color(0xFFF9784B)),
                 modifier = Modifier
                     .fillMaxWidth()
@@ -327,4 +301,213 @@ fun AddSpotView(onBackClick: () -> Unit, onSpotAdded: () -> Unit, addSpotViewMod
             }
         }
     }
+}
+
+@Composable
+fun SpotOnIconToggle(
+    checked: Boolean,
+    iconOn: DrawableResource,
+    iconOff: DrawableResource,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    IconToggleButton(
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        content = {
+            Image(
+                modifier = modifier.size(17.dp),
+                imageVector = vectorResource(if (checked) iconOn else iconOff),
+                contentDescription = null
+            )
+        }
+    )
+}
+
+@Composable
+fun AddSpotSearchBox(addSpotViewModel: AddSpotViewModel) {
+    val scope = rememberCoroutineScope()
+    val focusManager = LocalFocusManager.current
+    val suggestions by addSpotViewModel.suggestions.collectAsState()
+    val query by addSpotViewModel.query.collectAsState()
+    val suggestionGenerator = remember { SearchBoxFetcher() }
+
+    Column {
+        TextField(
+            label = { Text("Add Address") },
+            value = query,
+            onValueChange = {
+                addSpotViewModel.updateQuery(it)
+                if (it.trim().isNotEmpty()) {
+                    scope.launch {
+                        addSpotViewModel.updateSuggestions(
+                            suggestionGenerator.fetch(it)
+                        )
+                    }
+                }
+            },
+            colors = TextFieldDefaults.textFieldColors(
+                unfocusedIndicatorColor = Color.Transparent,
+                focusedIndicatorColor = Color.Transparent,
+                backgroundColor = Color.White,
+                cursorColor = Color.Gray,
+                focusedLabelColor = Color.DarkGray,
+                unfocusedLabelColor = Color.Gray,
+                textColor = Color.DarkGray
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(55.dp)
+                .shadow(8.dp, RoundedCornerShape(12.dp))
+                .background(color = Color.White, shape = RoundedCornerShape(12.dp))
+                .clip(RoundedCornerShape(12.dp))
+        )
+
+        if (suggestions.isNotEmpty()) {
+            LazyColumn(
+                modifier = Modifier.fillMaxWidth()
+                    .height(165.dp)
+                    .shadow(8.dp, RoundedCornerShape(12.dp))
+                    .background(Color.White)
+                    .clip(RoundedCornerShape(12.dp))
+            ) {
+                items(suggestions) { suggestion ->
+                    Text(
+                        text = suggestion.name,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(8.dp)
+                            .clickable {
+                                scope.launch {
+                                    suggestionGenerator.fetch(suggestion)?.let { feature ->
+                                        addSpotViewModel.updateCurrentLocation(
+                                            Coordinate(
+                                                feature.geometry.coordinates[0],
+                                                feature.geometry.coordinates[1]
+                                            )
+                                        )
+                                    }
+                                }
+                                focusManager.clearFocus()
+                                addSpotViewModel.updateQuery(suggestion.name)
+                                addSpotViewModel.updateSuggestions(emptyList())
+                                addSpotViewModel.updateSelectedAddress(suggestion.name)
+                            },
+                        color = Color.DarkGray,
+                    )
+                }
+            }
+        }
+
+    }
+}
+
+@Composable
+fun SpotOnSelectAvailability() {
+    var selectedWeekdays by remember { mutableStateOf(mutableMapOf(
+        "M" to true,
+        "Tu" to true,
+        "W" to true,
+        "Th" to true,
+        "F" to true,
+        "Sa" to false,
+        "Su" to false
+    )) }
+
+    var range by remember { mutableStateOf(32f..64f) }
+    val startMinutes = (range.start * 15).toInt()
+    val endMinutes = (range.endInclusive * 15).toInt()
+
+    val startHour = startMinutes / 60
+    val startMinute = startMinutes % 60
+    val endHour = endMinutes / 60
+    val endMinute = endMinutes % 60
+
+    val startHour12 = if (startHour % 12 == 0) 12 else startHour % 12
+    val startMeridian = if (startHour < 12) "AM" else "PM"
+    val endHour12 = if (endHour % 12 == 0) 12 else endHour % 12
+    val endMeridian = if (endHour < 12 || endHour == 24) "AM" else "PM"
+
+    Column {
+        Text("Set Availability")
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            for ((weekday, value) in selectedWeekdays) {
+                val borderColor = if (value) Color(0xFFF9784B) else Color.LightGray
+                val fontWeight = if (value) FontWeight.Bold else FontWeight.Thin
+
+                Button(
+                    modifier = Modifier
+                        .weight(1f / 7)
+                        .height(55.dp)
+                        .shadow(8.dp, RoundedCornerShape(12.dp))
+                        .border(
+                            width = 1.dp,
+                            color = borderColor,
+                            shape = RoundedCornerShape(12.dp)
+                        )
+                        .clip(RoundedCornerShape(12.dp)),
+                    shape = RoundedCornerShape(12.dp),
+                    colors = ButtonDefaults.buttonColors(backgroundColor = Color.White),
+                    onClick = {
+                        selectedWeekdays = selectedWeekdays.toMutableMap().apply {
+                            this[weekday] = !value
+                        }
+                    }
+                ) {
+                    Text(
+                        weekday.first().toString(),
+                        textAlign = TextAlign.Center,
+                        style = TextStyle(fontWeight = fontWeight)
+                    )
+                }
+            }
+        }
+
+        Column {
+            RangeSlider(
+                value = range,
+                onValueChange = {
+                    range = it
+
+                },
+                valueRange = 0f..96f,
+                steps = 95,
+                modifier = Modifier.fillMaxWidth(),
+                colors = SliderDefaults.colors(
+                    thumbColor = Color(0xFFF9784B),
+                    activeTrackColor = Color(0xFFF9784B),
+                    inactiveTrackColor = Color.LightGray,
+                    inactiveTickColor = Color.Transparent,
+                    activeTickColor = Color.Transparent
+                )
+            )
+
+            Text(
+                text = "${startHour12}:${startMinute.toString().padStart(2, '0')}" +
+                        " $startMeridian - ${endHour12}:${
+                            endMinute.toString().padStart(2, '0')
+                        } $endMeridian",
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+            )
+        }
+    }
+}
+
+fun parseNumberRange(input: String): List<Int> {
+    return input.split(",").map { it.trim() }
+        .flatMap { part ->
+            if ("-" in part) {
+                val rangeBounds = part.split("-").map { it.trim(); it.toInt() }
+                (rangeBounds[0]..rangeBounds[1]).toList()
+            } else {
+                listOf(part.toInt())
+            }
+        }
+        .filter { it > 0 }
 }


### PR DESCRIPTION
Added text box that takes spot numbers as an input in a format similar to 1,5-7,9. This will allow users to batch add parking spots that have the same information. Also added support for choosing spot availability times using a days of the week buttons and a range picker for the time. The steps of this range picker are 15 minutes for now but we can update this later if needed.

<img width="356" alt="image" src="https://github.com/user-attachments/assets/20fe8064-f942-409c-8ff8-15981aaa9aa4">
<img width="375" alt="image" src="https://github.com/user-attachments/assets/a9e5b801-5a11-4087-bbb7-54e3549b46b5">
<img width="347" alt="image" src="https://github.com/user-attachments/assets/ac337293-278e-4381-a5c3-ba86433e8fd7">
