### PR TITLE
Add Stripe on iOS

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/overdrive/cruiser/views/StripePaymentView.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/overdrive/cruiser/views/StripePaymentView.android.kt
@@ -1,0 +1,11 @@
+package com.overdrive.cruiser.views
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+actual fun StripePaymentView(
+    amount: Long,
+    onComplete: () -> Unit,
+    modifier: Modifier
+) { /* TODO */ }

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/NavigationBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/NavigationBar.kt
@@ -39,7 +39,7 @@ enum class Screen {
 @Composable
 fun NavigationBar() {
     var selectedScreen by remember { mutableStateOf(Screen.GetStarted) }
-    var noNavBarScreens = listOf(Screen.GetStarted, Screen.UserType, Screen.Login, Screen.Terms)
+    val noNavBarScreens = listOf(Screen.GetStarted, Screen.UserType, Screen.Login, Screen.Terms)
     val mapViewModel = remember { MapViewModel() }
     val userViewModel = remember { UserViewModel() }
     val mySpotsViewModel = remember { MySpotsViewModel() }

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SpotDetailView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/SpotDetailView.kt
@@ -20,8 +20,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
@@ -94,7 +92,8 @@ fun SpotDetailView(datePickerModel: DatePickerModel, spot: Spot, onBack: () -> U
             }
         ) { visible ->
             if (visible) {
-                Column(modifier = Modifier.fillMaxSize().background(color = Color(0xFFF5F5F5))
+                Column(
+                    modifier = Modifier.fillMaxSize().background(color = Color(0xFFF5F5F5))
                 ) {
                     DatePickerView(
                         datePickerModel = datePickerModel,
@@ -106,7 +105,8 @@ fun SpotDetailView(datePickerModel: DatePickerModel, spot: Spot, onBack: () -> U
                     )
                 }
             } else {
-                Column(modifier = Modifier.fillMaxSize().background(color = Color(0xFFF5F5F5))
+                Column(
+                    modifier = Modifier.fillMaxSize().background(color = Color(0xFFF5F5F5))
                 ) {
 
                     SpotOnTopBar("Spot Details", onBack)
@@ -186,63 +186,67 @@ fun SpotDetailView(datePickerModel: DatePickerModel, spot: Spot, onBack: () -> U
 
                         val tabs = listOf("Hourly", "Daily", "Schedule")
                         var hoursToBook by remember { mutableStateOf("1") }
-                        var timeToBook by remember{ mutableStateOf(1.hours) }
+                        var timeToBook by remember { mutableStateOf(1.hours) }
 
                         SpotOnTabRow(
                             tabs = tabs,
                             selectedTabIndex = selectedTab,
                             { selectedTab = it }
                         ) { i -> selectedTab = i }
-                            when (selectedTab) {
-                                0 -> SpotOnTextField(
-                                    value = hoursToBook,
-                                    onValueChange = { newValue ->
-                                        hoursToBook = newValue
-                                        val hours = newValue.toIntOrNull() ?: 1
-                                        timeToBook = hours.hours
-                                    },
-                                    label = "Hours to Book",
-                                    keyboardOptions = KeyboardOptions.Default.copy(
-                                        keyboardType = KeyboardType.Number
-                                    ),
-                                    modifier = Modifier.fillMaxWidth()
-                                )
-                                1 -> SpotOnTextField(
-                                    value = hoursToBook,
-                                    onValueChange = { newValue ->
-                                        hoursToBook = newValue
-                                        val days = newValue.toIntOrNull() ?: 1
-                                        timeToBook = days.days
-                                    },
-                                    label = "Days to Book",
-                                    keyboardOptions = KeyboardOptions.Default.copy(
-                                        keyboardType = KeyboardType.Number
-                                    ),
-                                    modifier = Modifier.fillMaxWidth()
-                                )
-                                2 -> SpotOnField(modifier = Modifier.fillMaxWidth().height(55.dp)) {
-                                    Row(
-                                        modifier = Modifier.padding(16.dp),
-                                        verticalAlignment = Alignment.CenterVertically
-                                    ) {
-                                        val selectedDate = datePickerState.selectedDateMillis?.let {
-                                            Instant.fromEpochMilliseconds(
-                                                it + 1.days.inWholeMilliseconds
-                                            ).toLocalDateTime(TimeZone.currentSystemDefault())
-                                        }
-                                        Text(
-                                            text = "${selectedDate?.dayOfMonth} ${selectedDate?.month?.name?.lowercase()?.capitalize()} ${selectedDate?.year}"
+                        when (selectedTab) {
+                            0 -> SpotOnTextField(
+                                value = hoursToBook,
+                                onValueChange = { newValue ->
+                                    hoursToBook = newValue
+                                    val hours = newValue.toIntOrNull() ?: 1
+                                    timeToBook = hours.hours
+                                },
+                                label = "Hours to Book",
+                                keyboardOptions = KeyboardOptions.Default.copy(
+                                    keyboardType = KeyboardType.Number
+                                ),
+                                modifier = Modifier.fillMaxWidth()
+                            )
+
+                            1 -> SpotOnTextField(
+                                value = hoursToBook,
+                                onValueChange = { newValue ->
+                                    hoursToBook = newValue
+                                    val days = newValue.toIntOrNull() ?: 1
+                                    timeToBook = days.days
+                                },
+                                label = "Days to Book",
+                                keyboardOptions = KeyboardOptions.Default.copy(
+                                    keyboardType = KeyboardType.Number
+                                ),
+                                modifier = Modifier.fillMaxWidth()
+                            )
+
+                            2 -> SpotOnField(modifier = Modifier.fillMaxWidth().height(55.dp)) {
+                                Row(
+                                    modifier = Modifier.padding(16.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    val selectedDate = datePickerState.selectedDateMillis?.let {
+                                        Instant.fromEpochMilliseconds(
+                                            it + 1.days.inWholeMilliseconds
+                                        ).toLocalDateTime(TimeZone.currentSystemDefault())
+                                    }
+                                    Text(
+                                        text = "${selectedDate?.dayOfMonth} ${
+                                            selectedDate?.month?.name?.lowercase()?.capitalize()
+                                        } ${selectedDate?.year}"
+                                    )
+                                    Spacer(modifier = Modifier.weight(1f))
+                                    IconButton(onClick = { isDatePickerVisible = true }) {
+                                        Icon(
+                                            imageVector = vectorResource(Res.drawable.saved_spots),
+                                            contentDescription = null
                                         )
-                                        Spacer(modifier = Modifier.weight(1f))
-                                        IconButton(onClick = { isDatePickerVisible = true }) {
-                                            Icon(
-                                                imageVector = vectorResource(Res.drawable.saved_spots),
-                                                contentDescription = null
-                                            )
-                                        }
                                     }
                                 }
                             }
+                        }
 
                         // Displaying content below based on the selected tab
                         Box(
@@ -254,20 +258,22 @@ fun SpotDetailView(datePickerModel: DatePickerModel, spot: Spot, onBack: () -> U
                             }
                         }
 
-                        SpotOnField(modifier = Modifier.fillMaxWidth()) {
-                            Button(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(55.dp),
-                                colors = ButtonDefaults.buttonColors(
-                                    backgroundColor = Color(
-                                        0xFFF9784B
-                                    )
-                                ),
-                                onClick = {
+                        SpotOnField(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(55.dp)
+                        ) {
+                            StripePaymentView(
+                                amount = 50,
+                                onComplete = {
                                     // TODO: since we aren't including seconds, we subtract 1 minute from the start time
-                                    val startTime = selectedTimeRange?.startTime() ?: Clock.System.now().minus(1.minutes).toLocalDateTime(TimeZone.currentSystemDefault())
-                                    val endTime = selectedTimeRange?.endTime() ?: Clock.System.now().plus(timeToBook).toLocalDateTime(TimeZone.currentSystemDefault())
+                                    val startTime =
+                                        selectedTimeRange?.startTime() ?: Clock.System.now()
+                                            .minus(1.minutes)
+                                            .toLocalDateTime(TimeZone.currentSystemDefault())
+                                    val endTime = selectedTimeRange?.endTime() ?: Clock.System.now()
+                                        .plus(timeToBook)
+                                        .toLocalDateTime(TimeZone.currentSystemDefault())
                                     val booking = Booking(
                                         id = "1234",
                                         parkingSpotId = spot.id,
@@ -282,10 +288,9 @@ fun SpotDetailView(datePickerModel: DatePickerModel, spot: Spot, onBack: () -> U
                                         bookingEndpoint.create(booking)
                                         onBack()
                                     }
-                                }
-                            ) {
-                                Text("Book Now", color = Color.White)
-                            }
+                                },
+                                modifier = Modifier.fillMaxSize()
+                            )
                         }
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/StripePaymentView.kt
+++ b/composeApp/src/commonMain/kotlin/com/overdrive/cruiser/views/StripePaymentView.kt
@@ -1,0 +1,16 @@
+package com.overdrive.cruiser.views
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * Displays a button to pay with Stripe.
+ *
+ * @param onComplete Callback to be invoked when the payment is completed successfully.
+ */
+@Composable
+expect fun StripePaymentView(
+    amount: Long,
+    onComplete: () -> Unit,
+    modifier: Modifier
+)

--- a/composeApp/src/iosMain/kotlin/com/overdrive/cruiser/ViewFactory.kt
+++ b/composeApp/src/iosMain/kotlin/com/overdrive/cruiser/ViewFactory.kt
@@ -4,9 +4,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import com.overdrive.cruiser.models.Coordinate
 import com.overdrive.cruiser.models.Spot
 import com.overdrive.cruiser.views.MapWithSwiftViewFactory
+import com.overdrive.cruiser.views.StripePaymentViewFactory
 import kotlinx.coroutines.flow.StateFlow
 
-// Called from Swift - initializes the MapView
+// Called from Swift - initializes view factories for iOS
 fun setViewFactories(
     mapWithSwiftViewFactory: (
         contentPaddingState: StateFlow<PaddingValues>,
@@ -14,6 +15,11 @@ fun setViewFactories(
         contentSpotsState: StateFlow<List<Spot>>,
         onSpotSelected: (Spot) -> Unit
     ) -> MapWithSwiftViewFactory,
+    stripePaymentViewFactory: (
+        Long,
+        () -> Unit
+    ) -> StripePaymentViewFactory
 ) {
     com.overdrive.cruiser.views.mapWithSwiftViewFactory = mapWithSwiftViewFactory
+    com.overdrive.cruiser.views.stripePaymentViewFactory = stripePaymentViewFactory
 }

--- a/composeApp/src/iosMain/kotlin/com/overdrive/cruiser/views/StripePaymentView.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/overdrive/cruiser/views/StripePaymentView.ios.kt
@@ -1,0 +1,34 @@
+package com.overdrive.cruiser.views
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.UIKit.UIViewController
+import androidx.compose.ui.interop.UIKitViewController
+
+
+@OptIn(ExperimentalForeignApi::class)
+@Composable
+actual fun StripePaymentView(
+    amount: Long,
+    onComplete: () -> Unit,
+    modifier: Modifier
+) {
+    val factory = remember { stripePaymentViewFactory(amount, onComplete) }
+
+    UIKitViewController(
+        factory = { factory.viewController },
+        update = { },
+        modifier = modifier,
+    )
+}
+
+internal lateinit var stripePaymentViewFactory: (
+    contentAmount: Long,
+    contentOnComplete: () -> Unit
+) -> StripePaymentViewFactory
+
+interface StripePaymentViewFactory {
+    val viewController: UIViewController
+}

--- a/composeApp/src/wasmJsMain/kotlin/com/overdrive/cruiser/views/StripePaymentView.wasm.kt
+++ b/composeApp/src/wasmJsMain/kotlin/com/overdrive/cruiser/views/StripePaymentView.wasm.kt
@@ -1,0 +1,11 @@
+package com.overdrive.cruiser.views
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+actual fun StripePaymentView(
+    amount: Long,
+    onComplete: () -> Unit,
+    modifier: Modifier
+) { /* TODO */ }

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -12,6 +12,10 @@
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
 		4036732C2CA330B100C30C77 /* MapSwiftView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4036732B2CA330B100C30C77 /* MapSwiftView.swift */; };
 		4036732F2CA331B200C30C77 /* MapboxMaps in Frameworks */ = {isa = PBXBuildFile; productRef = 4036732E2CA331B200C30C77 /* MapboxMaps */; };
+		40B7DCD32CF52F3300CBF33B /* StripePaymentsUI in Frameworks */ = {isa = PBXBuildFile; productRef = 40B7DCD22CF52F3300CBF33B /* StripePaymentsUI */; };
+		40B7DCD52CF5344A00CBF33B /* StripePaymentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B7DCD42CF5344A00CBF33B /* StripePaymentView.swift */; };
+		40B7DCD72CF5464600CBF33B /* StripePaymentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B7DCD62CF5464600CBF33B /* StripePaymentHandler.swift */; };
+		40B7DCD92CF5466E00CBF33B /* StripePaymentSheet in Frameworks */ = {isa = PBXBuildFile; productRef = 40B7DCD82CF5466E00CBF33B /* StripePaymentSheet */; };
 		40F016BD2CB0CE4C001E8687 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 40F016BC2CB0CE4C001E8687 /* GoogleSignIn */; };
 		40F016BF2CB0CE4C001E8687 /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 40F016BE2CB0CE4C001E8687 /* GoogleSignInSwift */; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
@@ -22,6 +26,8 @@
 		058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
 		4036732B2CA330B100C30C77 /* MapSwiftView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapSwiftView.swift; sourceTree = "<group>"; };
+		40B7DCD42CF5344A00CBF33B /* StripePaymentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripePaymentView.swift; sourceTree = "<group>"; };
+		40B7DCD62CF5464600CBF33B /* StripePaymentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripePaymentHandler.swift; sourceTree = "<group>"; };
 		7555FF7B242A565900829871 /* cruiser.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = cruiser.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -35,7 +41,9 @@
 			files = (
 				40F016BF2CB0CE4C001E8687 /* GoogleSignInSwift in Frameworks */,
 				4036732F2CA331B200C30C77 /* MapboxMaps in Frameworks */,
+				40B7DCD32CF52F3300CBF33B /* StripePaymentsUI in Frameworks */,
 				40F016BD2CB0CE4C001E8687 /* GoogleSignIn in Frameworks */,
+				40B7DCD92CF5466E00CBF33B /* StripePaymentSheet in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -84,6 +92,8 @@
 				2152FB032600AC8F00CF470E /* iOSApp.swift */,
 				058557D7273AAEEB004C7B11 /* Preview Content */,
 				4036732B2CA330B100C30C77 /* MapSwiftView.swift */,
+				40B7DCD42CF5344A00CBF33B /* StripePaymentView.swift */,
+				40B7DCD62CF5464600CBF33B /* StripePaymentHandler.swift */,
 			);
 			path = iosApp;
 			sourceTree = "<group>";
@@ -117,6 +127,8 @@
 				4036732E2CA331B200C30C77 /* MapboxMaps */,
 				40F016BC2CB0CE4C001E8687 /* GoogleSignIn */,
 				40F016BE2CB0CE4C001E8687 /* GoogleSignInSwift */,
+				40B7DCD22CF52F3300CBF33B /* StripePaymentsUI */,
+				40B7DCD82CF5466E00CBF33B /* StripePaymentSheet */,
 			);
 			productName = iosApp;
 			productReference = 7555FF7B242A565900829871 /* cruiser.app */;
@@ -150,6 +162,7 @@
 			packageReferences = (
 				4036732D2CA331B200C30C77 /* XCRemoteSwiftPackageReference "mapbox-maps-ios" */,
 				40F016BB2CB0CE4C001E8687 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
+				40B7DCD12CF52F3300CBF33B /* XCRemoteSwiftPackageReference "stripe-ios-spm" */,
 			);
 			productRefGroup = 7555FF7C242A565900829871 /* Products */;
 			projectDirPath = "";
@@ -198,8 +211,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				40B7DCD72CF5464600CBF33B /* StripePaymentHandler.swift in Sources */,
 				4036732C2CA330B100C30C77 /* MapSwiftView.swift in Sources */,
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
+				40B7DCD52CF5344A00CBF33B /* StripePaymentView.swift in Sources */,
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -413,6 +428,14 @@
 				minimumVersion = 11.0.0;
 			};
 		};
+		40B7DCD12CF52F3300CBF33B /* XCRemoteSwiftPackageReference "stripe-ios-spm" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/stripe/stripe-ios-spm";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 24.1.0;
+			};
+		};
 		40F016BB2CB0CE4C001E8687 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/google/GoogleSignIn-iOS";
@@ -428,6 +451,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 4036732D2CA331B200C30C77 /* XCRemoteSwiftPackageReference "mapbox-maps-ios" */;
 			productName = MapboxMaps;
+		};
+		40B7DCD22CF52F3300CBF33B /* StripePaymentsUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 40B7DCD12CF52F3300CBF33B /* XCRemoteSwiftPackageReference "stripe-ios-spm" */;
+			productName = StripePaymentsUI;
+		};
+		40B7DCD82CF5466E00CBF33B /* StripePaymentSheet */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 40B7DCD12CF52F3300CBF33B /* XCRemoteSwiftPackageReference "stripe-ios-spm" */;
+			productName = StripePaymentSheet;
 		};
 		40F016BC2CB0CE4C001E8687 /* GoogleSignIn */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/iosApp/iosApp/StripePaymentHandler.swift
+++ b/iosApp/iosApp/StripePaymentHandler.swift
@@ -1,0 +1,51 @@
+//
+//  StripePaymentHandler.swift
+//  iosApp
+//
+//  Created by Ethan Wright on 2024-11-25.
+//  Copyright © 2024 orgName. All rights reserved.
+//
+
+import Foundation
+import StripePaymentSheet
+import SwiftUI
+
+class StripePaymentHandler: ObservableObject {
+    let backendCheckoutUrl = URL(string: "http://localhost:8080/payment-sheet")!
+    @Published var paymentSheet: PaymentSheet?
+    @Published var paymentResult: PaymentSheetResult?
+
+    func preparePaymentSheet() {
+      var request = URLRequest(url: backendCheckoutUrl)
+      request.httpMethod = "POST"
+        
+      let task = URLSession.shared.dataTask(with: request, completionHandler: { [weak self] (data, response, error) in
+        guard let data = data,
+              let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String : Any],
+              let customerId = json["customer"] as? String,
+              let customerEphemeralKeySecret = json["ephemeralKey"] as? String,
+              let paymentIntentClientSecret = json["paymentIntent"] as? String,
+              let publishableKey = json["publishableKey"] as? String,
+              let self = self else {
+            // Handle error
+          return
+        }
+
+        STPAPIClient.shared.publishableKey = publishableKey
+        var configuration = PaymentSheet.Configuration()
+        configuration.merchantDisplayName = "Example, Inc."
+        configuration.customer = .init(id: customerId, ephemeralKeySecret: customerEphemeralKeySecret)
+        configuration.allowsDelayedPaymentMethods = true
+
+        DispatchQueue.main.async {
+          self.paymentSheet = PaymentSheet(paymentIntentClientSecret: paymentIntentClientSecret, configuration: configuration)
+        }
+      })
+        
+      task.resume()
+    }
+
+    func onPaymentCompletion(result: PaymentSheetResult) {
+      self.paymentResult = result
+    }
+}

--- a/iosApp/iosApp/StripePaymentView.swift
+++ b/iosApp/iosApp/StripePaymentView.swift
@@ -1,0 +1,104 @@
+//
+//  StripePaymentView.swift
+//  iosApp
+//
+//  Created by Ethan Wright on 2024-11-25.
+//  Copyright © 2024 orgName. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+import ComposeApp
+import StripePaymentSheet
+
+func stripePaymentViewFactory(
+    contentAmount: KotlinLong,
+    contentOnComplete: @escaping () -> KotlinUnit
+) -> StripePaymentViewFactory {
+    return StripePaymentViewContainer(
+        contentAmount: contentAmount,
+        contentOnComplete: contentOnComplete
+    )
+}
+
+class StripePaymentViewContainer: StripePaymentViewFactory {
+    var viewController: UIViewController
+    var stripe: StripePaymentHandler
+    
+    init(
+        contentAmount: KotlinLong,
+        contentOnComplete: @escaping () -> KotlinUnit
+    ) {
+        let stripe = StripePaymentHandler()
+        
+        self.stripe = stripe
+        self.viewController = UIHostingController(
+            rootView: StripePaymentView(
+                stripe: stripe,
+                amount: contentAmount,
+                onComplete: contentOnComplete
+            )
+        )
+    }
+}
+
+struct StripePaymentView: View {
+    @ObservedObject var stripe: StripePaymentHandler
+    
+    var amount: KotlinLong
+    var onComplete: () -> KotlinUnit
+    
+    var body: some View {
+        VStack {
+            if let paymentSheet = stripe.paymentSheet {
+                    PaymentSheet.PaymentButton(
+                        paymentSheet: paymentSheet,
+                        onCompletion: { result in
+                            switch result {
+                            case .completed:
+                                print("Payment successful!")
+                                onComplete()
+                            case .failed(let error):
+                                print("Payment failed: \(error.localizedDescription)")
+                            case .canceled:
+                                print("Payment canceled.")
+                            }
+                        }
+                    ) {
+                        payButton
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .ignoresSafeArea()
+            } else {
+                ProgressView("Loading Payment Sheet...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color.white)
+            }
+            if let result = stripe.paymentResult {
+                switch result {
+                case .completed:
+                  Text("Payment complete")
+                case .failed(let error):
+                  Text("Payment failed: \(error.localizedDescription)")
+                case .canceled:
+                  Text("Payment canceled.")
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .ignoresSafeArea()
+        .background(Color.clear)
+        .onAppear{
+            stripe.preparePaymentSheet()
+        }
+    }
+    
+    private var payButton: some View {
+        Text("Pay Now")
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color(red: 0xF9 / 255.0, green: 0x78 / 255.0, blue: 0x4B / 255.0))
+            .foregroundColor(.white)
+            .cornerRadius(12)
+            .ignoresSafeArea()
+    }
+}

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import ComposeApp
 import GoogleSignIn
+import StripePaymentsUI
 
 class AppDelegate: NSObject, UIApplicationDelegate {
 
@@ -8,8 +9,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     _ app: UIApplication,
     open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]
     ) -> Bool {
-        var handled: Bool
+        StripeAPI.defaultPublishableKey = "pk_test_51QLd7JHSPwdfxfQKhJ3Xy8f91p7Y89ApSN2I7ZTgPM71TGQzogmNmbiQExBW9RSl5MtDf49Cr4aN6tWeQvm20cWD00ZxsJFaBD"
         
+        var handled: Bool
         // Add any more custom url handles below
         handled = GIDSignIn.sharedInstance.handle(url)
 
@@ -23,7 +25,8 @@ struct iOSApp: App {
     
     init() {
         ViewFactoryKt.setViewFactories(
-            mapWithSwiftViewFactory: mapWithSwiftViewFactory
+            mapWithSwiftViewFactory: mapWithSwiftViewFactory,
+            stripePaymentViewFactory: stripePaymentViewFactory
         )
     }
     


### PR DESCRIPTION
This adds a Stripe checkout screen to the iOS version of our app. Since implementation is platform specific I omitted the other platforms for now.

The amounts are currently hard-coded, once we have some pricing data I can come back and change this.

For testing use the card number: `4242 4242 4242 4242` which will "complete" the payment process.

Since this app is in test mode, real card numbers won't work.

Here is what the payment sheet looks like:

![Screenshot 2024-11-26 at 10 15 25 AM](https://github.com/user-attachments/assets/407725e9-2a49-41d7-8435-219c83084a83)